### PR TITLE
Fix an issue that can occur if a build has no associated work items

### DIFF
--- a/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
+++ b/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
@@ -58,12 +58,16 @@ function Get-LinkedReleaseNotes($vssEndpoint, $comments, $workItems) {
 			$relatedWorkItemsUri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$($env:SYSTEM_TEAMPROJECTID)/_apis/build/builds/$($env:BUILD_BUILDID)/workitems?api-version=2.0"
 			Write-Host "Performing POST request to $relatedWorkItemsUri"
 			$relatedWorkItems = (Invoke-WebRequest -Uri $relatedWorkItemsUri -Method POST -Headers $headers -UseBasicParsing -ContentType "application/json") | ConvertFrom-Json
-			$workItemsUri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)/_apis/wit/workItems?ids=$(($relatedWorkItems.value.id) -join '%2C')"
-			Write-Host "Performing GET request to $workItemsUri"
-			$workItemsDetails = (Invoke-WebRequest -Uri $workItemsUri -Headers $headers -UseBasicParsing) | ConvertFrom-Json
 			
-			$workItemEditBaseUri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$($env:SYSTEM_TEAMPROJECTID)/_workitems/edit"
-			$workItemsDetails.value | ForEach-Object {$releaseNotes += "* [$($_.id)]($workItemEditBaseUri/$($_.id)): $($_.fields.'System.Title') [$($_.fields.'System.State')]$nl"}
+			Write-Host "Retrieved $($relatedWorkItems.count) work items"
+			if ($relatedWorkItems.count -gt 0) {
+				$workItemsUri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)/_apis/wit/workItems?ids=$(($relatedWorkItems.value.id) -join '%2C')"
+				Write-Host "Performing GET request to $workItemsUri"
+				$workItemsDetails = (Invoke-WebRequest -Uri $workItemsUri -Headers $headers -UseBasicParsing) | ConvertFrom-Json
+			
+				$workItemEditBaseUri = "$($env:SYSTEM_TEAMFOUNDATIONCOLLECTIONURI)$($env:SYSTEM_TEAMPROJECTID)/_workitems/edit"
+				$workItemsDetails.value | ForEach-Object {$releaseNotes += "* [$($_.id)]($workItemEditBaseUri/$($_.id)): $($_.fields.'System.Title') [$($_.fields.'System.State')]$nl"}
+			}
 		}
 	}
 	

--- a/source/CustomBuildSteps/CreateOctopusRelease/task.json
+++ b/source/CustomBuildSteps/CreateOctopusRelease/task.json
@@ -12,7 +12,7 @@
     "version": {
         "Major": 0,
         "Minor": 2,
-        "Patch": 7
+        "Patch": 8
     },
     "minimumAgentVersion": "1.82.0",
 	"groups": [


### PR DESCRIPTION
I've come across an issue with the Git support I've added in #4. It occurs when a build does not have any associated work items. If that's the case it will still try to retrieve the work item details, which fails obviously since there aren't any work items to begin with. This has been fixed in this PR.