### PR TITLE
Add Custom Notes argument to Octopus-CreateRelease

### DIFF
--- a/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
+++ b/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
@@ -8,6 +8,8 @@
 	[string] [Parameter(Mandatory = $false)]
 	$WorkItemReleaseNotes,
 	[string] [Parameter(Mandatory = $false)]
+	$CustomReleaseNotes,
+	[string] [Parameter(Mandatory = $false)]
 	$DeployTo,
 	[string] [Parameter(Mandatory = $false)]
 	$AdditionalArguments
@@ -121,6 +123,12 @@ function Create-ReleaseNotes($linkedItemReleaseNotes) {
 	if (-not [System.String]::IsNullOrWhiteSpace($linkedItemReleaseNotes)) {
 		$notes += "`r`n`r`n$linkedItemReleaseNotes"
 	}
+	
+	if(-not [System.String]::IsNullOrWhiteSpace($CustomReleaseNotes)) {
+		$notes += "`r`n`r`n**Custom Notes:**"
+		$notes += "`r`n`r`n$CustomReleaseNotes"
+	}
+	
 	$fileguid = [guid]::NewGuid()
 	$fileLocation = Join-Path -Path $env:BUILD_STAGINGDIRECTORY -ChildPath "release-notes-$fileguid.md"
 	$notes | Out-File $fileLocation -Encoding utf8

--- a/source/CustomBuildSteps/CreateOctopusRelease/task.json
+++ b/source/CustomBuildSteps/CreateOctopusRelease/task.json
@@ -63,6 +63,15 @@
 			"groupName": "releasenotes"
 		},
 		{
+			"name": "CustomReleaseNotes",
+			"type": "string",
+			"label": "Custom Notes",
+			"defaultValue": "",
+			"required": false,
+			"helpMarkDown": "Custom notes appended to Octopus Release notes",
+			"groupName": "releasenotes"
+		},
+		{
 			"name": "DeployTo",
 			"type": "string",
 			"label": "Deploy Release To",


### PR DESCRIPTION
Allow users to add their own notes to the Release Notes.  Useful for adding custom metadata to a release.