### PR TITLE
Added Work Item tags to Work Item listings in release notes. Fixed BUILD_REPOSITORY_PROVIDER constant for VSO.

### DIFF
--- a/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
+++ b/source/CustomBuildSteps/CreateOctopusRelease/Octopus-CreateRelease.ps1
@@ -144,7 +144,7 @@ function Create-ReleaseNotes($linkedItemReleaseNotes) {
 	}
 	$fileguid = [guid]::NewGuid()
 	$fileLocation = Join-Path -Path $env:BUILD_STAGINGDIRECTORY -ChildPath "release-notes-$fileguid.md"
-	$notes | Out-File $fileLocation
+	$notes | Out-File $fileLocation -Encoding utf8
 	
 	return "--releaseNotesFile=`"$fileLocation`""
 }


### PR DESCRIPTION
This is my first ever pull request, and my first ever Power shell work, go easy on me if I've missed anything.

Work Item calls to the VSO API don't seem to differ based on the BUILD_REPOSITORY_PROVIDER, the code within this conditional is now identical for both Git & VSO.  I left in the `if` in case there were differences I was not aware of.

I've added a method to attach work item tags to the work item listings.