### PR TITLE
Basic output to the TFS build summary page

### DIFF
--- a/source/VSTSExtensions/OctopusBuildTasks/CreateOctopusRelease/Octopus-CreateRelease.ps1
+++ b/source/VSTSExtensions/OctopusBuildTasks/CreateOctopusRelease/Octopus-CreateRelease.ps1
@@ -142,6 +142,12 @@ function Create-ReleaseNotes($linkedItemReleaseNotes) {
 	return "--releaseNotesFile=`"$fileLocation`""
 }
 
+function Output-BuildSummary($octopusUrl) {
+	$markdownFile = Join-Path $PSScriptRoot "Output.md"
+	$markdownContent = "Octopus release for project $ProjectName was created.`n[See the details here]($octopusUrl/app#/projects/$projectname/)"
+	$markdownContent | Out-File $markdownFile
+	Write-Host "##vso[task.addattachment type=Distributedtask.Core.Summary;name=Octopus Release;]$markdownFile"
+}
 
 ### Execution starts here ###
 
@@ -169,5 +175,9 @@ if (-not [System.String]::IsNullOrWhiteSpace($DeployTo)) {
 $octoPath = Get-PathToOctoExe
 Write-Output "Path to Octo.exe = $octoPath"
 Invoke-Tool -Path $octoPath -Arguments "create-release --project=`"$ProjectName`" --server=$octopusUrl $credentialParams $deployToParams $releaseNotesParam $AdditionalArguments"
+
+# Output content to the build summary page
+Output-BuildSummary $octopusUrl
+
 
 Write-Verbose "Finishing Octopus-CreateRelease.ps1"


### PR DESCRIPTION
For the TFS vNext build extension, I added basic output to the Build Summary page in TFS/VSTS about the created Octopus Release and a link to the project in Octopus. Ideally the link would be directly to the created release rather than just the project, but that would most likely involve parsing the output from Octo.exe where the version number is output. That can be in a later release ;-)

The way I use the extension, though, is that I always pass the "--version" parameter to the extension to control the version number of the release, and in that case I *know* what the version number will be. Potentially one could add a dedicated parameter for the version number, and if that is specified, that can be added to the URL. 

This is my first pull request, so hopefully I've done it right ;-) I pushed the extension (with a different name) to my VSTS instance, and tested it there.

I added a issue #34 suggesting this feature some time ago and a PR was suggested.