### PR TITLE
Trim trailing backslash on folder names in octo push

### DIFF
--- a/source/VSTSExtensions/OctopusBuildAndReleaseTasks/Tasks/Pack/Octopus-Pack.ps1
+++ b/source/VSTSExtensions/OctopusBuildAndReleaseTasks/Tasks/Pack/Octopus-Pack.ps1
@@ -27,6 +27,13 @@ try {
         $releaseNotesFileArg = "--releaseNotesFile=`"$NugetReleaseNotesFile`""
     }
 
+    if ($OutputPath){
+        $OutputPath = $OutputPath.TrimEnd('\')
+    }
+    if ($SourcePath){
+        $SourcePath = $SourcePath.TrimEnd('\')
+    }
+
     # Call Octo.exe
     $octoPath = Get-OctoExePath
     $Arguments = "pack --id=`"$PackageId`" --format=$PackageFormat --version=$PackageVersion --outFolder=`"$OutputPath`" --basePath=`"$SourcePath`" --author=`"$NugetAuthor`" --title=`"$NugetTitle`" --description=`"$NugetDescription`" --releaseNotes=`"$NuGetReleaseNotes`" $releaseNotesFileArg --overwrite=$Overwrite"


### PR DESCRIPTION
If paths handed to Octo have a trailing backslash that backslash acts as an escape character in the command line we build and escapes the " character we're trying to surround the path with, and we end up with the next argument added to the path. This PR just trims a trailing bashslash on OutputPath and SourcePath in the Pack command.