### PR TITLE
Fix widget configuration bug and broken connections

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -61,7 +61,7 @@ _ReSharper*
 *.ncrunch*
 .*crunch*.local.xml
 
-# Installshield output folder 
+# Installshield output folder
 [Ee]xpress
 
 # DocProject is a documentation generator add-in
@@ -102,7 +102,7 @@ ClientBin
 ~$*
 *.dbmdl
 Generated_Code #added for RIA/Silverlight projects
-*.swp 
+*.swp
 .idea
 
 # Backup & report files from converting an old project file to a newer
@@ -112,6 +112,8 @@ Backup*/
 UpgradeLog*.XML
 
 build/
+dist/
+.rpt2_cache/
 
 *.received.*
 *.DS_Store

--- a/source/VSTSExtensions/OctopusDashboardWidgets/Widgets/OctoProjectEnvironmentStatus/js/octo-status.js
+++ b/source/VSTSExtensions/OctopusDashboardWidgets/Widgets/OctoProjectEnvironmentStatus/js/octo-status.js
@@ -13,7 +13,11 @@ function OctopusStatusWidget() {
 
             var getOctopusStatus = function (widgetSettings) {
                 var settings = JSON.parse(widgetSettings.customSettings.data);
-
+                if(!settings || !settings.connectionId)
+                {
+                    $projectH2.text("Not configured");
+                    return WidgetHelpers.WidgetStatusHelper.Success();
+                }
                 // clear
                 $projectH2.text('Loading...');
                 $environmentH3.text('');
@@ -53,6 +57,11 @@ function OctopusStatusWidget() {
                                 headers: { 'Authorization': authToken }
                             })
                                 .done(function (data) {
+                                    if(data.errorMessage){
+                                        console.error(data.errorMessage);
+                                        return;
+                                    }
+
                                     var dashboard = JSON.parse(data.result[0]);    // todo: safely get last
                                     var deploymentElement = null;
                                     dashboard.Items.some(function (element) {

--- a/source/package-lock.json
+++ b/source/package-lock.json
@@ -1,0 +1,26 @@
+{
+  "name": "octopus-vsts",
+  "version": "1.0.0",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "q": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/q/-/q-1.5.1.tgz",
+      "integrity": "sha1-fjL3W0E4EpHQRhHxvxQQmsAGUdc="
+    },
+    "vss-web-extension-sdk": {
+      "version": "1.110.0",
+      "resolved": "https://registry.npmjs.org/vss-web-extension-sdk/-/vss-web-extension-sdk-1.110.0.tgz",
+      "integrity": "sha1-YaEJIdpRTi39K1USdbCt6h5QJa4="
+    },
+    "vsts-task-sdk": {
+      "version": "0.6.4",
+      "resolved": "https://registry.npmjs.org/vsts-task-sdk/-/vsts-task-sdk-0.6.4.tgz",
+      "integrity": "sha1-/AKbdLBrNo5gvoa1BiBI0Blb454=",
+      "requires": {
+        "q": "1.5.1"
+      }
+    }
+  }
+}


### PR DESCRIPTION
This PR fixes the following things:

* Initial load of the widget where configuration has not been set yet
* Fixes an issue where a broken connection breaks the ability to configure the widget
* Fixed an issue where configuring the widget when only a single project and environment is available results in the widget not being configurable at all
* Adds support to swap between octopus connections and repopulating dependant project and environment dropdowns

The initial load for the widget will now show "Not Configured" when initially added:

![image](https://user-images.githubusercontent.com/6700195/41288908-50d0eee8-6e8b-11e8-99c9-0d5703cf8d31.png)
