### PR TITLE
Drop DotNetCore demand

### DIFF
--- a/source/tasks/CreateOctopusRelease/task.json
+++ b/source/tasks/CreateOctopusRelease/task.json
@@ -15,9 +15,7 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-        "DotNetCore"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
         {

--- a/source/tasks/Deploy/task.json
+++ b/source/tasks/Deploy/task.json
@@ -15,9 +15,7 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-        "DotNetCore"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
          {

--- a/source/tasks/OctoCli/task.json
+++ b/source/tasks/OctoCli/task.json
@@ -15,9 +15,7 @@
         "Minor": 0,
         "Patch": 16
     },
-    "demands": [
-        "DotNetCore"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
         {

--- a/source/tasks/Pack/task.json
+++ b/source/tasks/Pack/task.json
@@ -15,8 +15,7 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
         {

--- a/source/tasks/Promote/task.json
+++ b/source/tasks/Promote/task.json
@@ -15,9 +15,7 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-        "DotNetCore"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
          {

--- a/source/tasks/Push/task.json
+++ b/source/tasks/Push/task.json
@@ -15,9 +15,7 @@
         "Minor": 0,
         "Patch": 0
     },
-    "demands": [
-        "DotNetCore"
-    ],
+    "demands": [],
     "minimumAgentVersion": "1.95.0",
     "groups": [
         {


### PR DESCRIPTION
Dropping the demand means that the tasks can run on a build agent which has a capability but hasn't been properly advertised or picked up. It also means that users can potentially target an agent which doesn't have DotNetCore installed and things will fail. We do however have an error message in place which makes it pretty obvious why things failed.