### PR TITLE
Embed Octo as part of installer task so that it can be used as a fall…

### DIFF
--- a/build/tasks/build.js
+++ b/build/tasks/build.js
@@ -33,7 +33,7 @@ gulp.task("build:copy", [], () => {
 });
 
 gulp.task("build:copy:task:content", ["build:tasks"], (cb) => {
-    var stream = gulp.src(`${paths.sourceRoot}tasks/**/*.{json,png,svg}`, { base: paths.sourceRoot}).pipe(gulp.dest(paths.outputPath));
+    var stream = gulp.src(`${paths.sourceRoot}tasks/**/*.{json,png,svg,zip,gz}`, { base: paths.sourceRoot}).pipe(gulp.dest(paths.outputPath));
 });
 
 gulp.task("build:copy:externals", ["build:tasks"], (cb) => {

--- a/deploy.ps1
+++ b/deploy.ps1
@@ -5,8 +5,9 @@ $version = $OctopusParameters["Octopus.Release.Number"]
 $accessToken = $OctopusParameters["AccessToken"]
 $shareWith = $OctopusParameters["ShareWith"]
 $publish = [System.Convert]::ToBoolean($OctopusParameters["Publish"])
+$embeddedOctoVersion = $OctopusParameters["EmbeddedOctoVersion"]
 
-& "$PSScriptRoot\pack.ps1" -environment $environment -version $version
+& "$PSScriptRoot\pack.ps1" -environment $environment -version $version -octoVersion $embeddedOctoVersion
 if ($publish) {
     & "$PSScriptRoot\publish.ps1" -environment $environment -version $version -accessToken $accessToken -shareWith $shareWith
 }

--- a/embed-octo.ps1
+++ b/embed-octo.ps1
@@ -1,0 +1,68 @@
+param (
+    [string]
+    $version = "latest",
+    $platform="portable",
+    [string]
+    $extension=".zip",
+    [string]
+    $latestOctoUrl = "https://g.octopushq.com/LatestTools"
+)
+
+$buildDirectoryPath = "$PSScriptRoot/dist"
+
+function Copy-Object($object){
+    $result = New-Object PsObject
+    $object.psobject.properties | ForEach-Object {
+        $result | Add-Member -MemberType $_.MemberType -Name $_.Name -Value $_.Value
+    }
+    return $result;
+}
+
+function Expand-Template($template, $option){
+    $result = $template;
+    $option.psobject.Properties | ForEach-Object { $result = $result -replace "{\s*$($_.Name)\s*}", $_.Value }
+    return $result;
+}
+
+function Update-Option($option, [HashTable]$overrides){
+    $result = Copy-Object $option
+    $overrides.Keys | ForEach-Object { $result.$_ = $overrides[$_] }
+    return $result;
+}
+function Resolve-Version($version, $option) {
+    if($version -ieq "latest"){
+        return $option
+    }else{
+      $result = Update-Option $option @{ version = $version }
+
+      $result.location = Expand-Template $result.template $result
+      return $result
+    }
+}
+
+function Resolve-InstallerTask($path){
+    $taskManifestFiles = Get-ChildItem $path -Include "task.json" -Recurse
+    foreach ($taskManifestFile in $taskManifestFiles) {
+        if((Split-Path (Split-Path $taskManifestFile -Parent) -Leaf) -ieq "OctoInstaller")
+        {
+            return Split-Path $taskManifestFile -Parent
+        }
+    }
+}
+
+$manifest = Invoke-RestMethod -Uri $latestOctoUrl
+$option = $manifest.downloads | Where-Object { $_.platform -ieq $platform -and $_.extension -ieq $extension }
+$option = Resolve-Version $version $option
+$name = (Split-Path $option.location -Leaf)
+$destinationFolder = Join-Path (Resolve-InstallerTask $buildDirectoryPath) "embedded"
+$destination = Join-Path $destinationFolder $name
+
+if(!(Test-Path $destinationFolder)){
+    New-Item -ItemType Directory -Path $destinationFolder | Out-Null
+}
+
+Write-Host "Downloading Octo $($option.version) from $($option.location) and saving to $($destination)"
+
+(New-Object System.Net.WebClient).DownloadFile($option.location, $destination)
+$Utf8NoBomEncoding = New-Object System.Text.UTF8Encoding $False
+[System.IO.File]::WriteAllLines( (Join-Path $destinationFolder "version.json"), (ConvertTo-Json $option -Compress -Depth 100), $Utf8NoBomEncoding)

--- a/pack.ps1
+++ b/pack.ps1
@@ -5,7 +5,9 @@ param (
     $environment,
     [Parameter(Mandatory=$true,HelpMessage="The three number version for this release")]
     [string]
-    $version
+    $version,
+    [string]
+    $embeddedOctoVersion
 )
 
 $ErrorActionPreference = "Stop"
@@ -136,6 +138,7 @@ function Pack($envName, $environment, $workingDirectory) {
     & tfx extension create --root $workingDirectory --manifest-globs extension-manifest.json --overridesFile $overridesFile --outputPath "$buildArtifactsPath/$environment" --no-prompt
 }
 
+& "$PSScriptRoot\embed-octo.ps1"-version $embeddedOctoVersion
 UpdateTfxCli
 InstallTaskDependencies $buildDirectoryPath
 Pack "VSTSExtensions" $environment $buildDirectoryPath

--- a/source/tasks/OctoInstaller/index.ts
+++ b/source/tasks/OctoInstaller/index.ts
@@ -1,4 +1,4 @@
-import { getOrDownloadOcto, resolvePublishedOctoVersion, addToolToPath } from "../Utils/install";
+import { getOrDownloadOcto, resolvePublishedOctoVersion, addToolToPath, getEmbeddedOcto } from "../Utils/install";
 import * as tasks from 'vsts-task-lib/task';
 
 async function run(){
@@ -6,12 +6,17 @@ async function run(){
     try{
         let version = await resolvePublishedOctoVersion(tasks.getInput("version"));
         console.log(`Using octo version ${version.version}`);
-        await getOrDownloadOcto(version)
-            .then(addToolToPath);
+        await getOrDownloadOcto(version).then(addToolToPath);
 
         tasks.setResult(tasks.TaskResult.Succeeded, "");
     }catch(error){
-        tasks.setResult(tasks.TaskResult.Failed, error);
+        console.log(`Failed to resolve latest octo version. Using embedded version. ${error}`);
+
+        try {
+            await getEmbeddedOcto(tasks.resolve(__dirname, "embedded")).then(addToolToPath);
+        }catch(embeddedOctoError){
+            tasks.setResult(tasks.TaskResult.Failed, embeddedOctoError);
+        }
     }
 }
 

--- a/webpack.config.ts
+++ b/webpack.config.ts
@@ -20,6 +20,10 @@ const createTaskConfig = (filePath: string): Configuration => {
 
     return {
         target: "node",
+        node:{
+            __dirname: false,
+            __filename: false
+        },
         context: path.resolve(paths.sourceRoot),
         entry: path.resolve(filePath),
         plugins: [],


### PR DESCRIPTION
…back when no internet connection is present

This PR allows Octo to be embedded as part of the installer task, which allows the installer task also to be used as a fallback when it fails to download a version of octo. This may be due to a build agent having no internet access etc.

Please note that we only embed the portable version of Octo at this point, so still requires the dotnet core runtime to be on the agent. The alternative to the above of course, is adding Octo to the path and registering it as a capability on the agent.