### PR TITLE
Fix an issue where build tasks fail on build agents prior to 2.115.0 with unexpected token

### DIFF
--- a/source/tasks/CreateOctopusRelease/task.json
+++ b/source/tasks/CreateOctopusRelease/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
         {
             "name": "releasenotes",

--- a/source/tasks/Deploy/task.json
+++ b/source/tasks/Deploy/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
          {
             "name": "tenant",

--- a/source/tasks/OctoCli/task.json
+++ b/source/tasks/OctoCli/task.json
@@ -16,7 +16,7 @@
         "Patch": 16
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/OctoInstaller/task.json
+++ b/source/tasks/OctoInstaller/task.json
@@ -21,7 +21,7 @@
     },
     "satisfies": ["Octo"],
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/Pack/task.json
+++ b/source/tasks/Pack/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
         {
             "name": "nuget",

--- a/source/tasks/Promote/task.json
+++ b/source/tasks/Promote/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
          {
             "name": "tenant",

--- a/source/tasks/Push/task.json
+++ b/source/tasks/Push/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "1.95.0",
+    "minimumAgentVersion": "2.115.0",
     "groups": [
         {
             "name": "advanced",

--- a/source/vsts.md
+++ b/source/vsts.md
@@ -6,7 +6,7 @@ This extension provides Build and Release tasks to integrate with [Octopus Deplo
 </div>
 
 ## Requirements
-For build agents being targeted, the dotnet core runtime 2.0 or later is required. When targeting build agents which do not have this capability, you can opt to use the dotnet installer task to satisfy this condition. An internet connection
+A minimum build agent version of `2.115.0` with dotnet core runtime 2.0 or later. When targeting build agents which do not have this capability, you can opt to use the dotnet installer task to satisfy this condition. An internet connection
 is also required for tasks to download the Octopus tools when not available on a build agent.
 
 ### VSTS Build Agents

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,6 +1,6 @@
 {
   "compilerOptions": {
-    "target": "es6",
+    "target": "es5",
     "module": "commonjs",
     "declaration": false,
     "sourceMap": false,
@@ -11,6 +11,9 @@
     "noFallthroughCasesInSwitch": true,
     "moduleResolution": "node",
     "baseUrl": "./source",
-    "allowSyntheticDefaultImports": true
+    "allowSyntheticDefaultImports": true,
+    "lib": [
+      "es2015"
+    ]
   }
 }


### PR DESCRIPTION
Fixes https://github.com/OctopusDeploy/OctoTFS/issues/100

Bumped the minimum agent requirement as tasks will fail on these old build agents with the version requirement. Targeted es5 in order to get a more meaningful error message i.e. replaces the error message unexpected token `{` with:

![image](https://user-images.githubusercontent.com/6700195/46511323-582da680-c891-11e8-920b-2f49410eefb1.png)
