### PR TITLE
Don't convert Build.BuildNumber to Number

### DIFF
--- a/source/tasks/Utils/environment.ts
+++ b/source/tasks/Utils/environment.ts
@@ -13,7 +13,7 @@ export interface ReleaseEnvironmentVariables {
 }
 
 export interface BuildEnvironmentVariables{
-    buildNumber: number;
+    buildNumber: string;
     buildId: number;
     buildName: string;
     buildRepositoryName: string;

--- a/source/tasks/Utils/environment.ts
+++ b/source/tasks/Utils/environment.ts
@@ -34,7 +34,7 @@ export const getVstsEnvironmentVariables= () : VstsEnvironmentVariables =>{
     return {
         projectId: process.env["SYSTEM_TEAMPROJECTID"],
         projectName: process.env["SYSTEM_TEAMPROJECT"],
-        buildNumber: Number(process.env["BUILD_BUILDNUMBER"]),
+        buildNumber: process.env["BUILD_BUILDNUMBER"],
         buildId: Number(process.env["BUILD_BUILDID"]),
         buildName: process.env["BUILD_DEFINITIONNAME"],
         buildRepositoryName: process.env["BUILD_REPOSITORY_NAME"],


### PR DESCRIPTION
Since Build.BuildNumber might be using SemVer 2.0.0 it will contain more than a number. Currently because of the Number convert it will output as #NaN