### PR TITLE
Add missing close heading markdown in release notes

### DIFF
--- a/source/tasks/Utils/environment.ts
+++ b/source/tasks/Utils/environment.ts
@@ -122,7 +122,7 @@ export const getLinkedReleaseNotes = async (client: vsts.WebApi, includeComments
                 console.log("Adding commit message to release notes");
                 releaseNotes += changes.reduce((prev, current) => {
                     return prev + `* [${current.id} - ${current.author.displayName}](${getCommitUrl(environment, current)}): ${current.message}${newLine}`;
-                }, `**Commit Messages:${newLine}`);
+                }, `**Commit Messages:**${newLine}`);
             } else {
                 /*
                     This could be any other git repo like Git, GitHub, SVN etc. We don't know
@@ -131,7 +131,7 @@ export const getLinkedReleaseNotes = async (client: vsts.WebApi, includeComments
                 console.log("Adding commit message to release notes");
                 releaseNotes += changes.reduce((prev, current) => {
                     return prev + `* ${current.id} - ${current.author.displayName}: ${current.message}${newLine}`;
-                }, `**Commit Messages:${newLine}`);
+                }, `**Commit Messages:**${newLine}`);
             }
         }
 


### PR DESCRIPTION
Fixes issue with `Commit Messages:` heading in auto-generated release notes