### PR TITLE
Filter environment dropdowns by project and optionally channel.

### DIFF
--- a/source/extension-manifest.json
+++ b/source/extension-manifest.json
@@ -227,6 +227,16 @@
                         "resultSelector": "jsonpath:$.[*]"
                     },
                     {
+                        "name": "OctopusProjectEnvironmentsInSpace",
+                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/environments/all?projectId=$(ProjectId)",
+                        "resultSelector": "jsonpath:$.[*]"
+                    },
+                    {
+                        "name": "OctopusProjectChannelEnvironmentsInSpace",
+                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/environments/all?projectId=$(ProjectId)&channelId=$(ChannelId)",
+                        "resultSelector": "jsonpath:$.[*]"
+                    },
+                    {
                         "name": "OctopusAllTenants",
                         "endpointUrl": "$(endpoint.url)/api/tenants/all",
                         "resultSelector": "jsonpath:$.[*]"

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -187,9 +187,11 @@
         {
             "target": "DeployToEnvironment",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusAllEnvironmentsInSpace",
+            "dataSourceName": "OctopusProjectChannelEnvironmentsInSpace",
             "parameters": {
-                "SpaceId": "$(Space)"
+                "SpaceId": "$(Space)",
+                "ProjectId": "$(ProjectName)",
+                "ChannelId": "$(Channel)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -137,9 +137,10 @@
         {
             "target": "Environments",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusAllEnvironmentsInSpace",
+            "dataSourceName": "OctopusProjectEnvironmentsInSpace",
             "parameters": {
-                "SpaceId": "$(Space)"
+                "SpaceId": "$(Space)",
+                "ProjectId": "$(Project)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -140,18 +140,20 @@
         {
             "target": "From",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusAllEnvironmentsInSpace",
+            "dataSourceName": "OctopusProjectEnvironmentsInSpace",
             "parameters": {
-                "SpaceId": "$(Space)"
+                "SpaceId": "$(Space)",
+                "ProjectId": "$(Project)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },
         {
             "target": "To",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusAllEnvironmentsInSpace",
+            "dataSourceName": "OctopusProjectEnvironmentsInSpace",
             "parameters": {
-                "SpaceId": "$(Space)"
+                "SpaceId": "$(Space)",
+                "ProjectId": "$(Project)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },


### PR DESCRIPTION
A relatively simple value addition: this filters environment dropdowns more responsively based on project and channel selections further up on the form.

Compatibility: This functionality won't work before Octopus Server 2019.7.2, but degrades back to the old behaviour of returning the full set of environments, so it will be safe to ship.