### PR TITLE
Fix space field help text and default

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -52,7 +52,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "",
+            "defaultValue": "Default",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -57,7 +57,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The space within Octopus. You can leave this blank to use the default space. (Octopus Deploy 2019.1+)"
+            "helpMarkDown": "The space within Octopus."
         },
         {
             "name": "ProjectName",

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -42,7 +42,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "",
+            "defaultValue": "Default",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -47,7 +47,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The space within Octopus. You can leave this blank to use the default space. (Octopus Deploy 2019.1+)"
+            "helpMarkDown": "The space within Octopus."
         },
         {
             "name": "Project",

--- a/source/tasks/Metadata/task.json
+++ b/source/tasks/Metadata/task.json
@@ -37,7 +37,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "",
+            "defaultValue": "Default",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Metadata/task.json
+++ b/source/tasks/Metadata/task.json
@@ -42,7 +42,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The space name within Octopus. You can leave this blank to use the default space. (Octopus Deploy 2019.1+)"
+            "helpMarkDown": "The space within Octopus."
         },
         {
             "name": "PackageId",

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -42,7 +42,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "",
+            "defaultValue": "Default",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -47,7 +47,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The space within Octopus. You can leave this blank to use the default space. (Octopus Deploy 2019.1+)"
+            "helpMarkDown": "The space within Octopus."
         },
         {
             "name": "Project",

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -42,7 +42,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The space within Octopus. You can leave this blank to use the default space. (Octopus Deploy 2019.1+)"
+            "helpMarkDown": "The space within Octopus."
         },
         {
             "name": "Package",

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -37,7 +37,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "",
+            "defaultValue": "Default",
             "required": true,
             "properties": {
                 "EditableOptions": "True"


### PR DESCRIPTION
A quick PR to:
* fix the misleading help text about leaving the space field blank in v4 tasks
* add a reasonable default of space "Default" for new tasks

***Note:***

I've tested this default, and found it doesn't interfere with upgraded settings, just for new task instances.

Of course we have no guarantee somebody's default space is called "Default", but I imagine it's still a pretty safe initial value. Let me know if you disagree, we can just back that commit out.
