### PR TITLE
Help text no longer states Octopus access required from AzDO server

### DIFF
--- a/source/extension-manifest.json
+++ b/source/extension-manifest.json
@@ -325,7 +325,7 @@
                         ]
                     }
                 ],
-                "helpMarkDown": "The Octopus URL must be accessible from both VSTS and any agents that are running builds or releases. See [g.octopushq.com/ApiKey](http://g.octopushq.com/ApiKey) for details on how to generate an API key."
+                "helpMarkDown": "The Octopus URL must be accessible from any agents that are running builds or releases. See [g.octopushq.com/ApiKey](http://g.octopushq.com/ApiKey) for details on how to generate an API key."
             }
         }
     ]


### PR DESCRIPTION
Removed from help text the requirement the Octopus must be accessible from AzDO server.  Only agents must be able to access Octopus server.
See https://twitter.com/wattengard/status/1160839046584819712