### PR TITLE
add overwrite-mode dropdowns (in place of replace checkboxes)

### DIFF
--- a/source/tasks/Metadata/index.ts
+++ b/source/tasks/Metadata/index.ts
@@ -6,10 +6,10 @@ import * as path from "path";
 import {
     connectionArguments,
     includeArguments,
-    flag,
     argument,
     argumentEnquote,
-    argumentIfSet
+    argumentIfSet,
+    getOverwriteModeFromReplaceInput
 } from '../Utils';
 
 export interface IOctopusPackageMetadata {
@@ -37,7 +37,7 @@ async function run() {
         const packageId = tasks.getInput("PackageId", true);
         const packageVersion = tasks.getInput("PackageVersion", true);
         const commentParser = tasks.getInput("CommentParser");
-        const replace = tasks.getBoolInput("Replace", true);
+        const overwriteMode = getOverwriteModeFromReplaceInput(tasks.getInput("Replace", true));
         const additionalArguments = tasks.getInput("AdditionalArguments");
 
         const commits = await utils.getBuildChanges(vstsConnection);
@@ -71,7 +71,7 @@ async function run() {
             argumentEnquote("package-id", packageId),
             argument("version", packageVersion),
             argumentEnquote("metadata-file", metadataFile),
-            flag("replace-existing", replace),
+            argument("overwrite-mode", overwriteMode),
             includeArguments(additionalArguments)
         ];
 

--- a/source/tasks/Metadata/index.ts
+++ b/source/tasks/Metadata/index.ts
@@ -62,6 +62,7 @@ async function run() {
         await tasks.mkdirP(metadataDir);
         await tasks.writeFile(metadataFile, JSON.stringify(metaData, null, 2));
 
+        await utils.assertOctoVersionAcceptsIds();
         const octo = await utils.getOrInstallOctoCommandRunner("push-metadata");
         const connection = utils.getDefaultOctopusConnectionDetailsOrThrow();
         const configure: Array<(tool: ToolRunner) => ToolRunner> = [

--- a/source/tasks/Metadata/task.json
+++ b/source/tasks/Metadata/task.json
@@ -80,7 +80,7 @@
             "label": "Overwrite Mode",
             "defaultValue": "false",
             "required": true,
-            "helpMarkDown": "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed ('Fail if exists'). You can use the overwrite mode to 'Overwrite existing' or 'Ignore if exists'.",
+            "helpMarkDown": "Normally, if the same package metadata already exists on the server, the server will reject the package metadata push. This is a good practice as it ensures metadata isn't accidentally overwritten or ignored. Use this setting to override this behavior.",
             "options": {
                 "false": "Fail if exists",
                 "true": "Overwrite existing",

--- a/source/tasks/Metadata/task.json
+++ b/source/tasks/Metadata/task.json
@@ -76,11 +76,16 @@
         },
         {
             "name": "Replace",
-            "type": "boolean",
-            "label": "Replace Existing",
-            "defaultValue": "False",
+            "type": "pickList",
+            "label": "Overwrite Mode",
+            "defaultValue": "false",
             "required": true,
-            "helpMarkDown": "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed. Set this to 'True' to overwrite the existing package metadata."
+            "helpMarkDown": "If the package metadata already exists in the repository, the default behavior is to reject the new package metadata being pushed ('Fail if exists'). You can use the overwrite mode to 'Overwrite existing' or 'Ignore if exists'.",
+            "options": {
+                "false": "Fail if exists",
+                "true": "Overwrite existing",
+                "IgnoreIfExists": "Ignore if exists"
+            }
         },
         {
             "name": "AdditionalArguments",

--- a/source/tasks/Push/PushV4/index.ts
+++ b/source/tasks/Push/PushV4/index.ts
@@ -5,9 +5,10 @@ import {
     multiArgument,
     connectionArguments,
     includeArguments,
-    flag,
+    argument,
     argumentEnquote,
-    argumentIfSet
+    argumentIfSet,
+    getOverwriteModeFromReplaceInput
 } from '../../Utils';
 
 async function run() {
@@ -16,7 +17,7 @@ async function run() {
 
         const space = tasks.getInput("Space");
         const packages = utils.getLineSeparatedItems(tasks.getInput("Package", true));
-        const replace = tasks.getBoolInput("Replace");
+        const overwriteMode = getOverwriteModeFromReplaceInput(tasks.getInput("Replace", true));
         const additionalArguments = tasks.getInput("AdditionalArguments");
 
         await utils.assertOctoVersionAcceptsIds();
@@ -27,7 +28,7 @@ async function run() {
             connectionArguments(connection),
             argumentIfSet(argumentEnquote, "space", space),
             multiArgument(argumentEnquote, "package", matchedPackages),
-            flag("replace-existing", replace),
+            argument("overwrite-mode", overwriteMode),
             includeArguments(additionalArguments)
         ];
 

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -54,11 +54,16 @@
         },
         {
             "name": "Replace",
-            "type": "boolean",
-            "label": "Replace Existing",
-            "defaultValue": "False",
+            "type": "pickList",
+            "label": "Overwrite Mode",
+            "defaultValue": "false",
             "required": true,
-            "helpMarkDown": "If the package already exists in the repository, the default behavior is to reject the new package being pushed. Set this flag to 'True' to overwrite the existing package."
+            "helpMarkDown": "If the package already exists in the repository, the default behavior is to reject the new package being pushed ('Fail if exists'). You can use the overwrite mode to 'Overwrite existing' or 'Ignore if exists'.",
+            "options": {
+                "false": "Fail if exists",
+                "true": "Overwrite existing",
+                "IgnoreIfExists": "Ignore if exists"
+            }
         },
         {
             "name": "AdditionalArguments",

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -58,7 +58,7 @@
             "label": "Overwrite Mode",
             "defaultValue": "false",
             "required": true,
-            "helpMarkDown": "If the package already exists in the repository, the default behavior is to reject the new package being pushed ('Fail if exists'). You can use the overwrite mode to 'Overwrite existing' or 'Ignore if exists'.",
+            "helpMarkDown": "Normally, if the same package already exists on the server, the server will reject the package push. This is a good practice as it ensures a package isn't accidentally overwritten or ignored. Use this setting to override this behavior.",
             "options": {
                 "false": "Fail if exists",
                 "true": "Overwrite existing",

--- a/source/tasks/Utils/inputs.ts
+++ b/source/tasks/Utils/inputs.ts
@@ -4,6 +4,16 @@ import * as glob from "glob";
 import { flatten } from "ramda";
 import { Promise } from "ts-promise";
 
+export enum ReplaceOverwriteMode {
+    false = 'FailIfExists',
+    true = 'OverwriteExisting',
+    IgnoreIfExists = 'IgnoreIfExists'
+}
+
+export function getOverwriteModeFromReplaceInput(replace: string): ReplaceOverwriteMode {
+    return ReplaceOverwriteMode[replace as keyof typeof ReplaceOverwriteMode] || ReplaceOverwriteMode.false;
+}
+
 export const DefaultOctoConnectionInputName = "OctoConnectedServiceName";
 
 export const pGlobNoNull = (pattern: string): Promise<string[]> => {

--- a/tests/OctoTFS.Tests/OctoTFS.Tests/ContractStabilityFixture.EnsureInputNamesAndTypesHaveNotChanged.approved.txt
+++ b/tests/OctoTFS.Tests/OctoTFS.Tests/ContractStabilityFixture.EnsureInputNamesAndTypesHaveNotChanged.approved.txt
@@ -52,7 +52,7 @@ OctoTFS.Tests.resources.tasks.Metadata.task.json
 	'PackageId': string
 	'PackageVersion': string
 	'CommentParser': pickList
-	'Replace': boolean
+	'Replace': pickList
 	'AdditionalArguments': string
 OctoTFS.Tests.resources.tasks.OctoCli.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
@@ -106,5 +106,5 @@ OctoTFS.Tests.resources.tasks.Push.PushV4.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': pickList
 	'Package': multiLine
-	'Replace': boolean
+	'Replace': pickList
 	'AdditionalArguments': string


### PR DESCRIPTION
Input continues to use `Replace` field name and values in order to inherit previous version settings.