### PR TITLE
Remove "Space" default value, as it wasn't being looked up to an id on init for new tasks

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -52,7 +52,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "Default",
+            "defaultValue": "",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -42,7 +42,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "Default",
+            "defaultValue": "",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Metadata/task.json
+++ b/source/tasks/Metadata/task.json
@@ -37,7 +37,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "Default",
+            "defaultValue": "",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -42,7 +42,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "Default",
+            "defaultValue": "",
             "required": true,
             "properties": {
                 "EditableOptions": "True"

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -37,7 +37,7 @@
             "name": "Space",
             "type": "pickList",
             "label": "Space",
-            "defaultValue": "Default",
+            "defaultValue": "",
             "required": true,
             "properties": {
                 "EditableOptions": "True"


### PR DESCRIPTION
_Background:_

The Space fields in tasks are designed to hold a space Id, but Azure DevOps can accept names and convert them too, for example if a user types a recognized name in. However this conversion doesn't trigger when adding a new step. The only non-hacky fix we know of is to stop trying to use a name as a default.