### PR TITLE
Require Channel selection so that dependent dropdowns work reliably

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -83,7 +83,7 @@
             "type": "pickList",
             "label": "Channel",
             "defaultValue": "",
-            "required": false,
+            "required": true,
             "properties": {
                 "EditableOptions": "True"
             },


### PR DESCRIPTION
The Environment dropdown depends on the Channel dropdown. Azure DevOps won't populate the Environment dropdown until a Channel selection is made. If the user leaves Channel blank, the Environment dropdown just stays broken, which is not a great user experience.

I think on balance, it's better to make this mandatory and get two more clicks from the user, than leave them with a broken Environment dropdown.