### PR TITLE
Replace docs links with Octopurls, to work around `+` problem

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
@@ -87,7 +87,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The [channel](http://docs.octopusdeploy.com/display/OD/Channels) to use for the release."
+            "helpMarkDown": "The [channel](https://g.octopushq.com/Channels) to use for the release."
         },
         {
             "name": "ChangesetCommentReleaseNotes",
@@ -164,7 +164,7 @@
             "label": "Additional Octo.exe Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Creating+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExeCreateRelease) for available parameters.",
             "groupName": "additional"
         }
     ],

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -87,7 +87,7 @@
             "properties": {
                 "EditableOptions": "True"
             },
-            "helpMarkDown": "The [channel](http://docs.octopusdeploy.com/display/OD/Channels) to use for the release."
+            "helpMarkDown": "The [channel](https://g.octopushq.com/Channels) to use for the release."
         },
         {
             "name": "ChangesetCommentReleaseNotes",
@@ -164,7 +164,7 @@
             "label": "Additional Octo.exe Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Creating+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExeCreateRelease) for available parameters.",
             "groupName": "additional"
         }
     ],

--- a/source/tasks/Deploy/DeployV3/task.json
+++ b/source/tasks/Deploy/DeployV3/task.json
@@ -114,7 +114,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Deploying+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExeDeployRelease) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -114,7 +114,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Deploying+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExeDeployRelease) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/tasks/Promote/PromoteV3/task.json
+++ b/source/tasks/Promote/PromoteV3/task.json
@@ -117,7 +117,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Promoting+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExePromoteRelease) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -117,7 +117,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Promoting+releases) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExePromoteRelease) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/tasks/Push/PushV3/task.json
+++ b/source/tasks/Push/PushV3/task.json
@@ -66,7 +66,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Pushing+packages) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExePush) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/tasks/Push/PushV4/task.json
+++ b/source/tasks/Push/PushV4/task.json
@@ -71,7 +71,7 @@
             "label": "Additional Arguments",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](http://docs.octopusdeploy.com/display/OD/Pushing+packages) for available parameters.",
+            "helpMarkDown": "Additional arguments to be supplied to Octo.exe. See [Octo.exe Command Line documentation](https://g.octopushq.com/OctoExePush) for available parameters.",
             "groupName": "advanced"
         }
     ],

--- a/source/vsts.md
+++ b/source/vsts.md
@@ -58,7 +58,7 @@ Alternatively, you can supply the tool using the system `PATH` environment varia
 
 ## <a name="package-application"></a>![Package Icon](img/octopus_package-03.png) Package Application for Octopus
 
-*Note: You can still use [OctoPack](http://docs.octopusdeploy.com/display/OD/Using+OctoPack) as part of your MSBuild task to package and push Nuget packages to Octopus when targeting full .NET framework projects.*
+*Note: You can still use [OctoPack](https://g.octopushq.com/ExternalToolOctoPack) as part of your MSBuild task to package and push Nuget packages to Octopus when targeting full .NET framework projects.*
 
 ![Configure Package Application Step](img/create-package-options.png)
 
@@ -117,9 +117,9 @@ Options include:
    * **To Environment**:  Optional environment to deploy to after release creation.
    * **Show Deployment Progress**: Whether to wait for the operation to finish, recording output in the log. When enabled, the task only succeeds if the operation finished successfully.
  * **Tenants** section:
-   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
-   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
- * **Additional Octo.exe Arguments**:  Any additional [Octo arguments](http://docs.octopusdeploy.com/display/OD/Creating+releases) to include.
+   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
+   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
+ * **Additional Octo.exe Arguments**:  Any additional [Octo arguments](https://g.octopushq.com/OctoExeCreateRelease) to include.
 
 ### <a name="deploy-octopus-release"></a>![Deploy Release Image](img/octopus_deploy-02.png) Deploy Octopus Release
 
@@ -134,8 +134,8 @@ Options include:
  * **Deploy to Environments**: Comma-separated list of environments to deploy to.
  * **Show Deployment Progress**: Whether to wait for the operation to finish, recording output in the log. When enabled, the task only succeeds if the operation finished successfully.
  * **Tenants** section:
-   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
-   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
+   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
+   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
  * **Additional Arguments**:  Any additional [Octo arguments](https://octopus.com/docs/octopus-rest-api/octo.exe-command-line/deploy-release) to include.
 
 ### <a name="promote-octopus-release"></a>![Promote Release Image](img/octopus_promote-05.png) Promote Octopus Release
@@ -150,8 +150,8 @@ Options include:
  * **Promote To**: The environment to promote a deployment to.
  * **Show Deployment Progress**: Whether to wait for the operation to finish, recording output in the log. When enabled, the task only succeeds if the operation finished successfully.
  * **Tenants** section:
-   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
-   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](http://docs.octopusdeploy.com/display/OD/Multi-tenant+deployments) by Octopus.
+   * **Tenant(s)**: Comma-separated list of tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
+   * **Tenant tag(s)**: Comma-separated list of tenant tags matching tenants to deploy to. Note that if completed, this will be treated as a [Tenanted Deployment](https://g.octopushq.com/MultiTenantDeployments) by Octopus.
  * **Additional Arguments**:  Any additional [Octo arguments](https://octopus.com/docs/octopus-rest-api/octo.exe-command-line/promote-release) to include.
 
 <hr/>


### PR DESCRIPTION
Azure DevOps was rendering `+` in hyperlinks as `%20`, which doesn't work with our docs redirects.

They should be Octopurls anyway, so I've switched them all over.