### PR TITLE
Detect when the agentBuildDirectory is null

### DIFF
--- a/source/tasks/BuildInformation/index.ts
+++ b/source/tasks/BuildInformation/index.ts
@@ -57,7 +57,7 @@ async function run() {
             Commits: commits.map(change => ({ Id: change.id, Comment: change.message }))
         };
 
-        if (!environment.agentBuildDirectory || environment.agentBuildDirectory == "") {
+        if (!environment.agentBuildDirectory) {
             tasks.error("The Build Information step requires build information and therefore is not compatible with use in a Release pipeline.");
             return;
         }

--- a/source/tasks/BuildInformation/index.ts
+++ b/source/tasks/BuildInformation/index.ts
@@ -57,6 +57,11 @@ async function run() {
             Commits: commits.map(change => ({ Id: change.id, Comment: change.message }))
         };
 
+        if (!environment.agentBuildDirectory || environment.agentBuildDirectory == "") {
+            tasks.error("The Build Information step requires build information and therefore is not compatible with use in a Release pipeline.");
+            return;
+        }
+
         const buildInformationDir = path.join(environment.agentBuildDirectory, "octo");
         const buildInformationFile = path.join(buildInformationDir, `${environment.buildId}-buildinformation.json`);
         await tasks.mkdirP(buildInformationDir);


### PR DESCRIPTION
When this happens we're in a Release pipeline, so return an error to that effect.

Fixes #166