### PR TITLE
Update for new casing of `octo.dll`, with fallback to the previous

### DIFF
--- a/source/tasks/Utils/tool.ts
+++ b/source/tasks/Utils/tool.ts
@@ -7,7 +7,8 @@ import { Option, some, none } from "fp-ts/lib/Option"
 import { Either, right, fromOption  } from "fp-ts/lib/Either";
 import { getOrDownloadOcto, addToolToPath, resolvePublishedOctoVersion } from './install';
 
-export const ToolName = "Octo";
+export const ToolName = "octo";
+export const ToolNameUntil6_17_3 = "Octo";
 
 
 export interface ArgFormatter{
@@ -75,7 +76,9 @@ export function getOctoCommandRunner(command: string) : Option<ToolRunner> {
 }
 
 export function getPortableOctoCommandRunner(command: string) : Option<ToolRunner>{
-    const octo = stringOption(tasks.which(`${ToolName}.dll`, false));
+    const octo = stringOption(
+        tasks.which(`${ToolName}.dll`, false)
+        || tasks.which(`${ToolNameUntil6_17_3}.dll`, false));
     const dotnet = tasks.which("dotnet", false);
 
     if (isNullOrWhitespace(dotnet)){

--- a/source/tasks/Utils/tool.ts
+++ b/source/tasks/Utils/tool.ts
@@ -66,10 +66,12 @@ export async function getOrInstallOctoCommandRunner(command: string) : Promise<E
 
 export function getOctoCommandRunner(command: string) : Option<ToolRunner> {
     const isWindows = /windows/i.test(tasks.osType());
-    if(isWindows){
-        return stringOption(tasks.which(`${ToolName}`, false))
-        .map(tasks.tool)
-        .map(x => x.arg(command));
+    if (isWindows) {
+        return stringOption(
+            tasks.which(`${ToolName}`, false)
+            || tasks.which(`${ToolNameUntil6_17_3}`, false))
+            .map(tasks.tool)
+            .map(x => x.arg(command));
     }
 
     return getPortableOctoCommandRunner(command);


### PR DESCRIPTION
This change updates the casing of `octo.dll` from the former `Octo.dll`, but also scans the old name as a fallback.