### PR TITLE
Look for both Octo and octo when searching local tool cache on agent

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 224
+        "Patch": 225
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Deploy/DeployV3/task.json
+++ b/source/tasks/Deploy/DeployV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 224
+        "Patch": 225
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Promote/PromoteV3/task.json
+++ b/source/tasks/Promote/PromoteV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 224
+        "Patch": 225
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Push/PushV3/task.json
+++ b/source/tasks/Push/PushV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 224
+        "Patch": 225
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Utils/install.ts
+++ b/source/tasks/Utils/install.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as tasks from 'azure-pipelines-task-lib/task';
 import * as tools from 'azure-pipelines-tool-lib/tool';
 import * as TypedRestClient from "typed-rest-client/RestClient";
-import { ToolName, ToolNameUntil6_17_3 } from "../Utils";
+import { ToolName, ToolNameBeforeV7 } from "../Utils";
 import { head, filter } from "ramda";
 
 interface LatestResponse {
@@ -53,11 +53,11 @@ function getExecutableExtention(): string {
 
 function getLocalTool(version:string): string {
     console.log("Checking local tool cache");
-    return tools.findLocalTool(ToolName, version) || tools.findLocalTool(ToolNameUntil6_17_3, version);
+    return tools.findLocalTool(ToolName, version) || tools.findLocalTool(ToolNameBeforeV7, version);
 }
 
 function findOcto(rootFolder: string){
-    var octoPath = [path.join(rootFolder, "*" + ToolName + getExecutableExtention()), path.join(rootFolder, "*" + ToolNameUntil6_17_3 + getExecutableExtention())];
+    var octoPath = [path.join(rootFolder, "*" + ToolName + getExecutableExtention()), path.join(rootFolder, "*" + ToolNameBeforeV7 + getExecutableExtention())];
     console.log(`Looking for ${octoPath}`);
     var allPaths = tasks.find(rootFolder);
     var matches = tasks.match(allPaths, octoPath, rootFolder);

--- a/source/tasks/Utils/install.ts
+++ b/source/tasks/Utils/install.ts
@@ -3,7 +3,7 @@ import * as fs from "fs";
 import * as tasks from 'azure-pipelines-task-lib/task';
 import * as tools from 'azure-pipelines-tool-lib/tool';
 import * as TypedRestClient from "typed-rest-client/RestClient";
-import { ToolName } from "../Utils";
+import { ToolName, ToolNameUntil6_17_3 } from "../Utils";
 import { head, filter } from "ramda";
 
 interface LatestResponse {
@@ -53,11 +53,11 @@ function getExecutableExtention(): string {
 
 function getLocalTool(version:string): string {
     console.log("Checking local tool cache");
-    return tools.findLocalTool(ToolName, version);
+    return tools.findLocalTool(ToolName, version) || tools.findLocalTool(ToolNameUntil6_17_3, version);
 }
 
 function findOcto(rootFolder: string){
-    var octoPath = path.join(rootFolder, "*" + ToolName + getExecutableExtention());
+    var octoPath = [path.join(rootFolder, "*" + ToolName + getExecutableExtention()), path.join(rootFolder, "*" + ToolNameUntil6_17_3 + getExecutableExtention())];
     console.log(`Looking for ${octoPath}`);
     var allPaths = tasks.find(rootFolder);
     var matches = tasks.match(allPaths, octoPath, rootFolder);

--- a/source/tasks/Utils/tool.ts
+++ b/source/tasks/Utils/tool.ts
@@ -8,7 +8,7 @@ import { Either, right, fromOption  } from "fp-ts/lib/Either";
 import { getOrDownloadOcto, addToolToPath, resolvePublishedOctoVersion } from './install';
 
 export const ToolName = "octo";
-export const ToolNameUntil6_17_3 = "Octo";
+export const ToolNameBeforeV7 = "Octo";
 
 
 export interface ArgFormatter{
@@ -69,7 +69,7 @@ export function getOctoCommandRunner(command: string) : Option<ToolRunner> {
     if (isWindows) {
         return stringOption(
             tasks.which(`${ToolName}`, false)
-            || tasks.which(`${ToolNameUntil6_17_3}`, false))
+            || tasks.which(`${ToolNameBeforeV7}`, false))
             .map(tasks.tool)
             .map(x => x.arg(command));
     }
@@ -80,7 +80,7 @@ export function getOctoCommandRunner(command: string) : Option<ToolRunner> {
 export function getPortableOctoCommandRunner(command: string) : Option<ToolRunner>{
     const octo = stringOption(
         tasks.which(`${ToolName}.dll`, false)
-        || tasks.which(`${ToolNameUntil6_17_3}.dll`, false));
+        || tasks.which(`${ToolNameBeforeV7}.dll`, false));
     const dotnet = tasks.which("dotnet", false);
 
     if (isNullOrWhitespace(dotnet)){


### PR DESCRIPTION
### `6.17.3` - `Octo.dll`
![image](https://user-images.githubusercontent.com/1035315/74498291-d3927400-4f2b-11ea-8897-45dc20af73d5.png)

![image](https://user-images.githubusercontent.com/1035315/74498317-f02eac00-4f2b-11ea-8ed2-825cfb06d820.png)

### `6.17.5` - `octo.dll`
![image](https://user-images.githubusercontent.com/1035315/74498336-089ec680-4f2c-11ea-8a14-d634d6457f63.png)

![image](https://user-images.githubusercontent.com/1035315/74498352-1b190000-4f2c-11ea-95d6-a4554e92ed01.png)
