### PR TITLE
Automatically bump patch numbers of all tasks including V3

### DIFF
--- a/pack.ps1
+++ b/pack.ps1
@@ -77,8 +77,8 @@ function UpdateTaskManifests($workingDirectory, $version, $envName) {
         if ($task.version.Major -gt 3) {
             $task.version.Major  = $netVersion.Major
             $task.version.Minor = $netVersion.Minor
-            $task.version.Patch = $netVersion.Build
         }
+        $task.version.Patch = $netVersion.Build
 
         $task.helpMarkDown = "Version: $version. [More Information](https://g.octopushq.com/TFS-VSTS)"
 

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 225
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Deploy/DeployV3/task.json
+++ b/source/tasks/Deploy/DeployV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 225
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Promote/PromoteV3/task.json
+++ b/source/tasks/Promote/PromoteV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 225
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",

--- a/source/tasks/Push/PushV3/task.json
+++ b/source/tasks/Push/PushV3/task.json
@@ -13,7 +13,7 @@
     "version": {
         "Major": 3,
         "Minor": 0,
-        "Patch": 225
+        "Patch": 0
     },
     "demands": [],
     "minimumAgentVersion": "2.115.0",


### PR DESCRIPTION
# Background

The V4 tasks' patch version is based on build number, injected when Octopus calls `deploy.ps1`.
The V3 tasks' patch version is manually maintained in git.

But because V3 and V4 share some library code and embedded `octo`, their content in the `.vsix` changes over time, and if V3's version doesn't advance, those resources get fixated at whatever version was current at first install, making it tricky to diagnose or fix.

We also at some point went backwards in patch versions, so our manual patch version bumps weren't reaching all instances.

# Change

This change causes V3 tasks to use the same constantly-advancing patch version as V4 tasks, so they will continually reflect what we are currently building and delivering in the `.vsix`.