### PR TITLE
Adding project group support

### DIFF
--- a/source/extension-manifest.json
+++ b/source/extension-manifest.json
@@ -207,13 +207,23 @@
                         "resultSelector": "jsonpath:$.[*]"
                     },
                     {
-                        "name": "OctopusListProjects",
-                        "endpointUrl": "$(endpoint.url)/api/projects?partialName=$(PartialNameFilter)",
+                        "name": "OctopusAllProjectGroups",
+                        "endpointUrl": "$(endpoint.url)/api/projectgroups/all",
+                        "resultSelector": "jsonpath:$.[*]"
+                    },
+                    {
+                        "name": "OctopusAllProjectGroupsInSpace",
+                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/projectgroups/all",
+                        "resultSelector": "jsonpath:$.[*]"
+                    },
+                    {
+                        "name": "OctopusListProjectsInProjectGroup",
+                        "endpointUrl": "$(endpoint.url)/api/projectgroups/$(ProjectGroupId)/projects?take=500",
                         "resultSelector": "jsonpath:$.Items[*]"
                     },
                     {
-                        "name": "OctopusListProjectsInSpace",
-                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/projects?partialName=$(PartialNameFilter)",
+                        "name": "OctopusListProjectsInProjectGroupInSpace",
+                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/projectgroups$(ProjectGroupId)/projects?take=500",
                         "resultSelector": "jsonpath:$.Items[*]"
                     },
                     {

--- a/source/extension-manifest.json
+++ b/source/extension-manifest.json
@@ -223,7 +223,7 @@
                     },
                     {
                         "name": "OctopusListProjectsInProjectGroupInSpace",
-                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/projectgroups$(ProjectGroupId)/projects?take=500",
+                        "endpointUrl": "$(endpoint.url)/api/$(SpaceId)/projectgroups/$(ProjectGroupId)/projects?take=500",
                         "resultSelector": "jsonpath:$.Items[*]"
                     },
                     {

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
@@ -60,12 +60,15 @@
             "helpMarkDown": "Version 3 of this task has limited support for spaces. We recommend using version 4 of this task for a better experience."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "ProjectName",
@@ -178,11 +181,17 @@
     ],
     "dataSourceBindings": [
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroups",
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "ProjectName",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjects",
+            "dataSourceName": "OctopusListProjectsInProjectGroup",
             "parameters": {
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -60,12 +60,15 @@
             "helpMarkDown": "The space within Octopus."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "ProjectName",
@@ -184,12 +187,21 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroupsInSpace",
+            "parameters": {
+                "SpaceId": "$(Space)"
+            },
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "ProjectName",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjectsInSpace",
+            "dataSourceName": "OctopusListProjectsInProjectGroupInSpace",
             "parameters": {
                 "SpaceId": "$(Space)",
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Deploy/DeployV3/task.json
+++ b/source/tasks/Deploy/DeployV3/task.json
@@ -50,12 +50,15 @@
             "helpMarkDown": "Version 3 of this task has limited support for spaces. We recommend using version 4 of this task for a better experience."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "Project",
@@ -128,11 +131,17 @@
     ],
     "dataSourceBindings": [
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroups",
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "Project",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjects",
+            "dataSourceName": "OctopusListProjectsInProjectGroup",
             "parameters": {
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Deploy/DeployV4/task.json
+++ b/source/tasks/Deploy/DeployV4/task.json
@@ -50,12 +50,15 @@
             "helpMarkDown": "The space within Octopus."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "Project",
@@ -134,12 +137,21 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroupsInSpace",
+            "parameters": {
+                "SpaceId": "$(Space)"
+            },
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "Project",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjectsInSpace",
+            "dataSourceName": "OctopusListProjectsInProjectGroupInSpace",
             "parameters": {
                 "SpaceId": "$(Space)",
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Promote/PromoteV3/task.json
+++ b/source/tasks/Promote/PromoteV3/task.json
@@ -50,12 +50,15 @@
             "helpMarkDown": "Version 3 of this task has limited support for spaces. We recommend using version 4 of this task for a better experience."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "Project",
@@ -131,11 +134,17 @@
     ],
     "dataSourceBindings": [
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroups",
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "Project",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjects",
+            "dataSourceName": "OctopusListProjectsInProjectGroup",
             "parameters": {
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/tasks/Promote/PromoteV4/task.json
+++ b/source/tasks/Promote/PromoteV4/task.json
@@ -50,12 +50,15 @@
             "helpMarkDown": "The space within Octopus."
         },
         {
-            "name": "ProjectFilter",
-            "type": "string",
-            "label": "Filter project by name",
+            "name": "ProjectGroup",
+            "type": "pickList",
+            "label": "Project Group",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "This helps you narrow the next Project dropdown with more specific results."
+            "properties": {
+                "EditableOptions": "True"
+            },
+            "helpMarkDown": "The project group within Octopus (this populates the next Project dropdown)."
         },
         {
             "name": "Project",
@@ -137,12 +140,21 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },
         {
+            "target": "ProjectGroup",
+            "endpointId": "$(OctoConnectedServiceName)",
+            "dataSourceName": "OctopusAllProjectGroupsInSpace",
+            "parameters": {
+                "SpaceId": "$(Space)"
+            },
+            "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
+        },
+        {
             "target": "Project",
             "endpointId": "$(OctoConnectedServiceName)",
-            "dataSourceName": "OctopusListProjectsInSpace",
+            "dataSourceName": "OctopusListProjectsInProjectGroupInSpace",
             "parameters": {
                 "SpaceId": "$(Space)",
-                "PartialNameFilter": "$(ProjectFilter)"
+                "ProjectGroupId": "$(ProjectGroup)"
             },
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         },

--- a/source/widgets/ProjectStatus/configuration.html
+++ b/source/widgets/ProjectStatus/configuration.html
@@ -15,15 +15,16 @@
                     <select id="octopus-space"></select>
                 </div>
             </div>
-            <div>
+            <div class="dropdown">
+                <label>Octopus Project Group</label>
+                <div class="wrapper">
+                    <select id="octopus-project-group"></select>
+                </div>
+            </div>
+            <div class="dropdown">
                 <label>Octopus Project</label>
                 <div class="wrapper">
-                    <input type="text" id="octopus-project-filter" placeholder="Filter project by name (optional)" />
-                </div>
-                <div class="dropdown">
-                    <div class="wrapper">
-                        <select id="octopus-project"></select>
-                    </div>
+                    <select id="octopus-project"></select>
                 </div>
             </div>
             <div class="dropdown">

--- a/source/widgets/ProjectStatus/js/configuration.js
+++ b/source/widgets/ProjectStatus/js/configuration.js
@@ -126,7 +126,7 @@ function OctopusStatusWidgetConfiguration() {
                         appendSpaceData(data);
                         const selectedSpaceId = $spaceDropdown.val();
 
-                        fetchDataSourceContent(queryUri, authToken, "OctopusListProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
+                        fetchDataSourceContent(queryUri, authToken, "OctopusAllProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
                             appendProjectGroupData(projectGroupData);
                             const selectedProjectGroupId = $projectGroupDropdown.val();
                             fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroupInSpace", selectedSpaceId, selectedProjectGroupId).done(appendProjectData);
@@ -153,7 +153,7 @@ function OctopusStatusWidgetConfiguration() {
                 var appendProjectGroupData = appendDropdownOptions($projectGroupDropdown, parseResult, selectId, selectName, settings ? settings.projectGroupId : null);
                 var appendProjectData = appendDropdownOptions($projectDropdown, parseResult, selectId, selectName, settings ? settings.projectId : null);
 
-                fetchDataSourceContent(queryUri, authToken, "OctopusListProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
+                fetchDataSourceContent(queryUri, authToken, "OctopusAllProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
                     appendProjectGroupData(projectGroupData);
                     const selectedProjectGroupId = $projectGroupDropdown.val();
                     fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroupInSpace", selectedSpaceId, selectedProjectGroupId).done(appendProjectData);

--- a/source/widgets/ProjectStatus/js/configuration.js
+++ b/source/widgets/ProjectStatus/js/configuration.js
@@ -4,17 +4,19 @@ function OctopusStatusWidgetConfiguration() {
         VSS.register("OctoProjectEnvironmentWidget.Configuration", function () {
             var $connectionDropdown = $("#octopus-connection");
             var $spaceDropdown = $("#octopus-space");
-            var $projectFilterInput = $("#octopus-project-filter");
+            var $projectGroupDropdown = $("#octopus-project-group");
             var $projectDropdown = $("#octopus-project");
             var $environmentDropdown = $("#octopus-environment");
 
-            var saveSettings = function (configurationContext, connectionId, spaceId, spaceName, projectId, projectName, environmentId, environmentName) {
-                console.debug("Saving settings - Connection: " + connectionId + ", Space: " + spaceId + ", Project: " + projectId + ", Environment: " + environmentId);
+            var saveSettings = function (configurationContext, connectionId, spaceId, spaceName, projectGroupId, projectGroupName, projectId, projectName, environmentId, environmentName) {
+                console.debug("Saving settings - Connection: " + connectionId + ", Space: " + spaceId + ", ProjectGroup: " + projectGroupId + ", Project: " + projectId + ", Environment: " + environmentId);
                 var customSettings = {
                     data: JSON.stringify({
                         connectionId: connectionId,
                         spaceId: spaceId,
                         spaceName: spaceName,
+                        projectGroupId: projectGroupId,
+                        projectGroupName: projectGroupName,
                         projectId: projectId,
                         projectName: projectName,
                         environmentId: environmentId,
@@ -30,15 +32,13 @@ function OctopusStatusWidgetConfiguration() {
                 return customSettings;
             };
 
-            var fetchDataSourceContent = function (queryUri, token, name, spaceId, partialNameFilter) {
+            var fetchDataSourceContent = function (queryUri, token, name, spaceId, projectGroupId) {
                 let parameters = [];
                 if (spaceId) {
                     parameters.push('"SpaceId":"' + spaceId + '"');
                 }
-
-                // We check explicitly for `null` in this case. There are cases where we need to pass an empty string through to our endpointUrl.
-                if (partialNameFilter != null) {
-                    parameters.push('"PartialNameFilter":"' + partialNameFilter + '"');
+                if (projectGroupId) {
+                    parameters.push('"ProjectGroupId":"' + projectGroupId + '"');
                 }
 
                 // TODO: Refactor - we should really include interfaces for these and JSON.stringify() instead of string concatenation like this.
@@ -107,56 +107,67 @@ function OctopusStatusWidgetConfiguration() {
                 return (prop("result")(data) || []).map(JSON.parse);
             };
 
-            var refreshSpacesProjectsAndEnvironmentsDropdowns = function (settings, queryUri, authToken) {
+            var refreshSpacesProjectGroupsAndEnvironmentsDropdowns = function (settings, queryUri, authToken) {
                 $spaceDropdown.empty();
                 $spaceDropdown.prop("disabled", true);
-                $projectFilterInput.empty();
+                $projectGroupDropdown.empty();
                 $projectDropdown.empty();
                 $environmentDropdown.empty();
 
                 const appendSpaceData = appendDropdownOptions($spaceDropdown, parseResult, selectId, selectName, settings ? settings.spaceId : null);
+                const appendProjectGroupData = appendDropdownOptions($projectGroupDropdown, parseResult, selectId, selectName, settings ? settings.projectGroupId : null);
                 const appendProjectData = appendDropdownOptions($projectDropdown, parseResult, selectId, selectName, settings ? settings.projectId : null);
                 const appendEnvironmentData = appendDropdownOptions($environmentDropdown, parseResult, selectId, selectName, settings ? settings.environmentId : null);
-
-                // TODO: Review - this results in undesired UX when editing an existing widget (you end up with two project names on top of each other).
-                // TODO: With all the onChange events going on here, how can we achieve this nicely using our new list endpoints? (consider projects that do _not_ exist in the first page of results).
-                if (settings && settings.projectName) {
-                    // Populate our project search with our project name.
-                    $projectFilterInput.val(settings.projectName);
-                }
 
                 fetchDataSourceContent(queryUri, authToken, "OctopusAllSpaces", null, null).done(function (data) {
                     const hasSpaces = !data.errorMessage;
                     if (hasSpaces) {
                         $spaceDropdown.prop("disabled", false);
                         appendSpaceData(data);
-
                         const selectedSpaceId = $spaceDropdown.val();
-                        fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInSpace", selectedSpaceId, $projectFilterInput.val()).done(appendProjectData);
+
+                        fetchDataSourceContent(queryUri, authToken, "OctopusListProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
+                            appendProjectGroupData(projectGroupData);
+                            const selectedProjectGroupId = $projectGroupDropdown.val();
+                            fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroupInSpace", selectedSpaceId, selectedProjectGroupId).done(appendProjectData);
+                        });
+
                         fetchDataSourceContent(queryUri, authToken, "OctopusAllEnvironmentsInSpace", selectedSpaceId, null).done(appendEnvironmentData);
                     } else {
-                        fetchDataSourceContent(queryUri, authToken, "OctopusListProjects", null, $projectFilterInput.val()).done(appendProjectData);
+                        fetchDataSourceContent(queryUri, authToken, "OctopusListProjectGroups", null, null).done(function (projectGroupData) {
+                            appendProjectGroupData(projectGroupData);
+                            const selectedProjectGroupId = $projectGroupDropdown.val();
+                            fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroup", null, selectedProjectGroupId).done(appendProjectData);
+                        });
+
                         fetchDataSourceContent(queryUri, authToken, "OctopusAllEnvironments", null, null).done(appendEnvironmentData);
                     }
                 });
             };
 
-            var refreshProjectsAndEnvironmentsInSpaceDropdowns = function (settings, queryUri, authToken, spaceId, projectNameFilter) {
+            var refreshProjectGroupsAndEnvironmentsInSpaceDropdowns = function (settings, queryUri, authToken, spaceId) {
+                $projectGroupDropdown.empty();
                 $projectDropdown.empty();
                 $environmentDropdown.empty();
 
+                var appendProjectGroupData = appendDropdownOptions($projectGroupDropdown, parseResult, selectId, selectName, settings ? settings.projectGroupId : null);
                 var appendProjectData = appendDropdownOptions($projectDropdown, parseResult, selectId, selectName, settings ? settings.projectId : null);
-                fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInSpace", spaceId, projectNameFilter).done(appendProjectData);
+
+                fetchDataSourceContent(queryUri, authToken, "OctopusListProjectGroupsInSpace", selectedSpaceId, null).done(function (projectGroupData) {
+                    appendProjectGroupData(projectGroupData);
+                    const selectedProjectGroupId = $projectGroupDropdown.val();
+                    fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroupInSpace", selectedSpaceId, selectedProjectGroupId).done(appendProjectData);
+                });
 
                 var appendEnvironmentData = appendDropdownOptions($environmentDropdown, parseResult, selectId, selectName, settings ? settings.environmentId : null);
                 fetchDataSourceContent(queryUri, authToken, "OctopusAllEnvironmentsInSpace", spaceId, null).done(appendEnvironmentData);
             };
 
-            var refreshProjectsInSpaceDropdowns = function (settings, queryUri, authToken, spaceId, projectNameFilter) {
+            var refreshProjectsInSpaceDropdowns = function (settings, queryUri, authToken, spaceId, projectGroupId) {
                 $projectDropdown.empty();
 
                 var appendProjectData = appendDropdownOptions($projectDropdown, parseResult, selectId, selectName, settings ? settings.projectId : null);
-                fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInSpace", spaceId, projectNameFilter).done(appendProjectData);
+                fetchDataSourceContent(queryUri, authToken, "OctopusListProjectsInProjectGroupInSpace", spaceId, projectGroupId).done(appendProjectData);
             };
 
             var getConnectionQueryUri = function (baseUri, $element) {
@@ -185,7 +196,7 @@ function OctopusStatusWidgetConfiguration() {
                             }).done(function (data) {
                                 appendDropdownOptions($connectionDropdown, prop("value"), selectId, selectName, settings ? settings.connectionId : null)(data);
                                 var queryUri = getConnectionQueryUri(baseUri, $connectionDropdown);
-                                refreshSpacesProjectsAndEnvironmentsDropdowns(settings, queryUri(), authToken);
+                                refreshSpacesProjectGroupsAndEnvironmentsDropdowns(settings, queryUri(), authToken);
 
                                 $connectionDropdown.on("change", function () {
                                     saveSettings(
@@ -193,12 +204,14 @@ function OctopusStatusWidgetConfiguration() {
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
                                         $(":selected", $environmentDropdown).text()
                                     );
-                                    refreshSpacesProjectsAndEnvironmentsDropdowns(settings, queryUri(), authToken);
+                                    refreshSpacesProjectGroupsAndEnvironmentsDropdowns(settings, queryUri(), authToken);
                                 });
 
                                 $spaceDropdown.on("change", function () {
@@ -207,26 +220,30 @@ function OctopusStatusWidgetConfiguration() {
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
                                         $(":selected", $environmentDropdown).text()
                                     );
-                                    refreshProjectsAndEnvironmentsInSpaceDropdowns(settings, queryUri(), authToken, $spaceDropdown.val(), $projectFilterInput.val());
+                                    refreshProjectGroupsAndEnvironmentsInSpaceDropdowns(settings, queryUri(), authToken, $spaceDropdown.val());
                                 });
 
-                                $projectFilterInput.on("change", function () {
+                                $projectGroupDropdown.on("change", function () {
                                     saveSettings(
                                         widgetConfigurationContext,
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
                                         $(":selected", $environmentDropdown).text()
                                     );
-                                    refreshProjectsInSpaceDropdowns(settings, queryUri(), authToken, $spaceDropdown.val(), $projectFilterInput.val());
+                                    refreshProjectsInSpaceDropdowns(settings, queryUri(), authToken, $spaceDropdown.val(), $projectGroupDropdown.val());
                                 });
 
                                 $projectDropdown.on("change", function () {
@@ -235,6 +252,8 @@ function OctopusStatusWidgetConfiguration() {
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
@@ -248,6 +267,8 @@ function OctopusStatusWidgetConfiguration() {
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
@@ -262,6 +283,8 @@ function OctopusStatusWidgetConfiguration() {
                                         $connectionDropdown.val(),
                                         $spaceDropdown.val(),
                                         $(":selected", $spaceDropdown).text(),
+                                        $projectGroupDropdown.val(),
+                                        $(":selected", $projectGroupDropdown).text(),
                                         $projectDropdown.val(),
                                         $(":selected", $projectDropdown).text(),
                                         $environmentDropdown.val(),
@@ -280,6 +303,8 @@ function OctopusStatusWidgetConfiguration() {
                         $connectionDropdown.val(),
                         $spaceDropdown.val(),
                         $(":selected", $spaceDropdown).text(),
+                        $projectGroupDropdown.val(),
+                        $(":selected", $projectGroupDropdown).text(),
                         $projectDropdown.val(),
                         $(":selected", $projectDropdown).text(),
                         $environmentDropdown.val(),

--- a/tests/OctoTFS.Tests/OctoTFS.Tests/ContractStabilityFixture.EnsureInputNamesAndTypesHaveNotChanged.approved.txt
+++ b/tests/OctoTFS.Tests/OctoTFS.Tests/ContractStabilityFixture.EnsureInputNamesAndTypesHaveNotChanged.approved.txt
@@ -8,7 +8,7 @@
 OctoTFS.Tests.resources.tasks.CreateOctopusRelease.CreateOctopusReleaseV3.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': string
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'ProjectName': pickList
 	'ReleaseNumber': string
 	'Channel': pickList
@@ -23,7 +23,7 @@ OctoTFS.Tests.resources.tasks.CreateOctopusRelease.CreateOctopusReleaseV3.task.j
 OctoTFS.Tests.resources.tasks.CreateOctopusRelease.CreateOctopusReleaseV4.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': pickList
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'ProjectName': pickList
 	'ReleaseNumber': string
 	'Channel': pickList
@@ -38,7 +38,7 @@ OctoTFS.Tests.resources.tasks.CreateOctopusRelease.CreateOctopusReleaseV4.task.j
 OctoTFS.Tests.resources.tasks.Deploy.DeployV3.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': string
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'Project': pickList
 	'ReleaseNumber': string
 	'Environments': pickList
@@ -49,7 +49,7 @@ OctoTFS.Tests.resources.tasks.Deploy.DeployV3.task.json
 OctoTFS.Tests.resources.tasks.Deploy.DeployV4.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': pickList
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'Project': pickList
 	'ReleaseNumber': string
 	'Environments': pickList
@@ -82,7 +82,7 @@ OctoTFS.Tests.resources.tasks.Pack.task.json
 OctoTFS.Tests.resources.tasks.Promote.PromoteV3.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': string
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'Project': pickList
 	'From': pickList
 	'To': pickList
@@ -93,7 +93,7 @@ OctoTFS.Tests.resources.tasks.Promote.PromoteV3.task.json
 OctoTFS.Tests.resources.tasks.Promote.PromoteV4.task.json
 	'OctoConnectedServiceName': connectedService:OctopusEndpoint
 	'Space': pickList
-	'ProjectFilter': string
+	'ProjectGroup': pickList
 	'Project': pickList
 	'From': pickList
 	'To': pickList


### PR DESCRIPTION
This [previous PR](https://github.com/OctopusDeploy/OctoTFS/pull/183) was re-tested before releasing to production and UX issues were found that were too concerning.

This PR takes the approach of filtering by Project Group in order to select Projects.

This is not entirely future proof, as you could have a lot of projects in one project group with LARGE descriptions and still max out the 2MB response limit on Azure. However, this does offer our customers an easy workaround: "Split your projects up into smaller project groups"

This avoids all the UX limitations and issues we have around project name searching/filtering from the previous PR and should unblock the customer who's hitting the 2MB response limit. It also offers us a valid workaround if customers encounter this problem in the future, without us having to completely re-write our extension with the newer libraries just yet.

Fixes OctopusDeploy/OctoTFS#182

## Reviewer notes

We have setup a TentacleArmy instance with a large number of projects to emulate the problem and confirm the fix:
https://marksazuredevopstest.tentaclearmy.com:8085

We have deployed this to our test azure devops instance:
https://octopus-deploy-test.visualstudio.com/MarkS%20Large%20Instance%20Test

This instance has a service connection pointing to our TentacleArmy:
https://octopus-deploy-test.visualstudio.com/MarkS%20Large%20Instance%20Test/_settings/adminservices

If you configure the dashboard for that project:
https://octopus-deploy-test.visualstudio.com/MarkS%20Large%20Instance%20Test/_dashboards/dashboard/efb8d933-b086-485d-9f0d-07e838a3eb69

You can use the overflow menu to configure that widget and confirm you can select any project using the new project group controls.

You can also play around with our test instance to confirm this fixes the problems and existing tasks are able to be used without problem.