### PR TITLE
Extend api token length

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,7 +31,7 @@ Microsoft TFS/ADO web extensions are powered by Node.js under the hood. Simply o
 * NPM: 5.6.0+ (`npm install npm@latest -g`)
 * TFX (`npm install tfx-cli -g`)
 * Install golang (`choco install golang` or `brew install go` or [web](https://golang.org))
-* Node-Prune (`go get github.com/tj/node-prune/cmd/node-prune`)
+* Node-Prune (`go get github.com/tj/node-prune`)
 * PowerShell (`choco install powershell-core` or `brew cask install powershell` or web (google it...))
 
 NOTE: PowerShell is required if you intend to publish the extension either to a local TFS instance or otherwise.

--- a/source/extension-manifest.json
+++ b/source/extension-manifest.json
@@ -323,7 +323,7 @@
                                 "validation": {
                                     "isRequired": true,
                                     "dataType": "string",
-                                    "maxLength": 32
+                                    "maxLength": 36
                                 }
                             }
                         ],


### PR DESCRIPTION
# Background 

Fix the maximum length of an API key when creating an Octopus Deploy service endpoint.

[Trello Card](https://trello.com/c/6E5v5VdO/4132-api-keys-are-too-long-for-azure-devops)

## Cause of this fix

[PR](https://github.com/OctopusDeploy/OctopusDeploy/pull/7611) to extend the API key length in Octopus Server

# How to review this PR

Quality :heavy_check_mark:
<!-- Describe focus areas (if any): Review tests/ Exploratory testing/ Smoke testing? -->

# Pre-requisites
- [x] I have considered informing or consulting the right people, e.g.: 
  - For changes to the execution pipeline: [`#topic-execution`](https://octopusdeploy.slack.com/archives/C3KT1DFSM)
  - For other changes, consider the other `#topic-...` channels
- [x] I have considered whether this should be a patch or wait for a minor.
- [x] I have considered appropriate testing for my change.
    <!-- Describe what has been covered: Automated testing/ Exploratory testing/ Nothing required? 
         Is the build green? -->
      