### PR TITLE
Add timeout and proxy config for tasks

### DIFF
--- a/source/tasks/BuildInformation/index.ts
+++ b/source/tasks/BuildInformation/index.ts
@@ -3,7 +3,7 @@ import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
 import * as utils from "../Utils";
 import * as path from "path";
 
-import { connectionArguments, includeArguments, argument, argumentEnquote, argumentIfSet, getOverwriteModeFromReplaceInput, multiArgument } from "../Utils";
+import { connectionArguments, includeAdditionalArgumentsAndDefaults, argument, argumentEnquote, argumentIfSet, getOverwriteModeFromReplaceInput, multiArgument } from "../Utils";
 
 export interface IOctopusBuildInformation {
     BuildEnvironment: string;
@@ -66,7 +66,7 @@ async function run() {
             argument("version", packageVersion),
             argumentEnquote("file", buildInformationFile),
             argument("overwrite-mode", overwriteMode),
-            includeArguments(additionalArguments),
+            includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
 
 async function run() {
     try {
@@ -28,7 +28,7 @@ async function run() {
             linkedReleaseNotes = await utils.getLinkedReleaseNotes(vstsConnection, changesetCommentReleaseNotes, workItemReleaseNotes);
         }
 
-        const realseNotesFile = utils.createReleaseNotesFile(() => {
+        const releaseNotesFile = utils.createReleaseNotesFile(() => {
             return utils.generateReleaseNotesContent(environmentVariables, linkedReleaseNotes, customReleaseNotes);
         }, environmentVariables.defaultWorkingDirectory);
 
@@ -43,8 +43,8 @@ async function run() {
             flag("progress", deployToEnvironments.length > 0 && deploymentProgress),
             multiArgument(argumentEnquote, "tenant", deployForTenants),
             multiArgument(argumentEnquote, "tenanttag", deployForTenantTags),
-            argumentEnquote("releaseNotesFile", realseNotesFile),
-            includeArguments(additionalArguments),
+            argumentEnquote("releaseNotesFile", releaseNotesFile),
+            includeAdditionalArgumentsAndDefaults(octoConnection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils";
 
 async function run() {
     try {
@@ -51,7 +51,7 @@ async function run() {
             configure.push(argumentEnquote("releaseNotesFile", releaseNotesFile));
         }
 
-        configure.push(includeArguments(additionalArguments));
+        configure.push(includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments));
 
         const code: Number = await octo
             .map((x) => x.launchOcto(configure))

--- a/source/tasks/Deploy/DeployV3/index.ts
+++ b/source/tasks/Deploy/DeployV3/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
 
 async function run() {
     try {
@@ -26,7 +26,7 @@ async function run() {
             multiArgument(argumentEnquote, "tenant", deploymentForTenants),
             multiArgument(argumentEnquote, "tenanttag", deployForTenantTags),
             flag("progress", showProgress),
-            includeArguments(additionalArguments),
+            includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/Deploy/DeployV4/index.ts
+++ b/source/tasks/Deploy/DeployV4/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils";
 
 async function run() {
     try {
@@ -14,7 +14,6 @@ async function run() {
         const deployForTenantTags = utils.getOptionalCsvInput("DeployForTenantTags");
         const showProgress = tasks.getBoolInput("ShowProgress");
         const additionalArguments = tasks.getInput("AdditionalArguments");
-
         await utils.assertOctoVersionAcceptsIds();
         const octo = await utils.getOrInstallOctoCommandRunner("deploy-release");
 
@@ -27,7 +26,7 @@ async function run() {
             multiArgument(argumentEnquote, "tenant", deployForTenants),
             multiArgument(argumentEnquote, "tenanttag", deployForTenantTags),
             flag("progress", showProgress),
-            includeArguments(additionalArguments),
+            includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/OctoCli/index.ts
+++ b/source/tasks/OctoCli/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../Utils";
-import { connectionArguments, includeArguments } from "../Utils/tool";
+import { connectionArguments, includeAdditionalArguments } from "../Utils/tool";
 
 async function run() {
     try {
@@ -9,7 +9,7 @@ async function run() {
         const command = tasks.getInput("command", true);
         const octo = await utils.getOrInstallOctoCommandRunner(command);
 
-        const configure = [connectionArguments(connection), includeArguments(args)];
+        const configure = [connectionArguments(connection), includeAdditionalArguments(args)];
 
         const code: Number = await octo
             .map((x) => x.launchOcto(configure))

--- a/source/tasks/Pack/index.ts
+++ b/source/tasks/Pack/index.ts
@@ -1,9 +1,8 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as fs from "fs";
 import * as utils from "../Utils";
-import { argument, argumentIfSet, flag, multiArgument, argumentEnquote } from "../Utils";
+import { argument, argumentIfSet, flag, multiArgument, argumentEnquote, includeAdditionalArguments } from "../Utils";
 import { ToolRunner } from "azure-pipelines-task-lib/toolrunner";
-import { includeArguments } from "../Utils";
 
 export interface PackageRequiredInputs {
     packageId: string;
@@ -40,7 +39,7 @@ export const configure = (inputs: PackageInputs) => {
         argumentIfSet(argumentEnquote, "description", inputs.nuGetDescription),
         argumentIfSet(argumentEnquote, "releaseNotes", inputs.nuGetReleaseNotes),
         argument("overwrite", inputs.overwrite.toString()),
-        includeArguments(inputs.additionalArguments),
+        includeAdditionalArguments(inputs.additionalArguments),
         (tool: ToolRunner) => {
             if (!utils.isNullOrWhitespace(inputs.nuGetReleaseNotesFile) && fs.existsSync(inputs.nuGetReleaseNotesFile) && fs.lstatSync(inputs.nuGetReleaseNotesFile).isFile()) {
                 console.log(`Release notes file: ${inputs.nuGetReleaseNotesFile}`);

--- a/source/tasks/Promote/PromoteV3/index.ts
+++ b/source/tasks/Promote/PromoteV3/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
 
 async function run() {
     try {
@@ -27,7 +27,7 @@ async function run() {
             multiArgument(argumentEnquote, "tenant", deploymentForTenants),
             multiArgument(argumentEnquote, "tenanttag", deployForTenantTags),
             flag("progress", showProgress),
-            includeArguments(additionalArguments),
+            includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/Promote/PromoteV4/index.ts
+++ b/source/tasks/Promote/PromoteV4/index.ts
@@ -1,6 +1,6 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils";
 
 async function run() {
     try {
@@ -27,7 +27,7 @@ async function run() {
             multiArgument(argumentEnquote, "tenant", deployForTenants),
             multiArgument(argumentEnquote, "tenanttag", deployForTenantTags),
             flag("progress", showProgress),
-            includeArguments(additionalArguments),
+            includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments),
         ];
 
         const code: Number = await octo

--- a/source/tasks/Push/PushV3/index.ts
+++ b/source/tasks/Push/PushV3/index.ts
@@ -1,7 +1,7 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
 
-import { multiArgument, connectionArguments, includeArguments, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, flag, argumentEnquote, argumentIfSet } from "../../Utils/tool";
 
 async function run() {
     try {
@@ -15,7 +15,7 @@ async function run() {
         const octo = await utils.getOrInstallOctoCommandRunner("push");
         const matchedPackages = await utils.resolveGlobs(packages);
 
-        const configure = [connectionArguments(connection), argumentIfSet(argumentEnquote, "space", space), multiArgument(argumentEnquote, "package", matchedPackages), flag("replace-existing", replace), includeArguments(additionalArguments)];
+        const configure = [connectionArguments(connection), argumentIfSet(argumentEnquote, "space", space), multiArgument(argumentEnquote, "package", matchedPackages), flag("replace-existing", replace), includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments)];
 
         const code: Number = await octo
             .map((x) => x.launchOcto(configure))

--- a/source/tasks/Push/PushV4/index.ts
+++ b/source/tasks/Push/PushV4/index.ts
@@ -1,7 +1,7 @@
 import * as tasks from "azure-pipelines-task-lib/task";
 import * as utils from "../../Utils";
 
-import { multiArgument, connectionArguments, includeArguments, argument, argumentEnquote, argumentIfSet, getOverwriteModeFromReplaceInput } from "../../Utils";
+import { multiArgument, connectionArguments, includeAdditionalArgumentsAndDefaults, argument, argumentEnquote, argumentIfSet, getOverwriteModeFromReplaceInput } from "../../Utils";
 
 async function run() {
     try {
@@ -16,7 +16,7 @@ async function run() {
         const octo = await utils.getOrInstallOctoCommandRunner("push");
         const matchedPackages = await utils.resolveGlobs(packages);
 
-        const configure = [connectionArguments(connection), argumentIfSet(argumentEnquote, "space", space), multiArgument(argumentEnquote, "package", matchedPackages), argument("overwrite-mode", overwriteMode), includeArguments(additionalArguments)];
+        const configure = [connectionArguments(connection), argumentIfSet(argumentEnquote, "space", space), multiArgument(argumentEnquote, "package", matchedPackages), argument("overwrite-mode", overwriteMode), includeAdditionalArgumentsAndDefaults(connection.url, additionalArguments)];
 
         const code: Number = await octo
             .map((x) => x.launchOcto(configure))

--- a/source/tasks/Utils/tool.ts
+++ b/source/tasks/Utils/tool.ts
@@ -128,7 +128,32 @@ export const argumentEnquote = curry((name: string, value: string | null | undef
     return argument(name, `"${value}"`, tool);
 });
 
-export const includeArguments = curry((value: string, tool: ToolRunner) => {
+export const includeAdditionalArgumentsAndDefaults = curry((url: string, value: string, tool: ToolRunner) => {
+    const timeoutRegex = /-timeout=/;
+    const proxyRegex = /-proxy=/;
+
+    if (!timeoutRegex.test(value)){
+        argument("timeout", "86400", tool); // We increase the timeout to 24h so it does not use the default 10mins timeout
+    }
+
+    const proxyConfig = tasks.getHttpProxyConfiguration(url)
+
+    if(proxyConfig) {
+        if (!proxyRegex.test(value)){
+            argument("proxy", proxyConfig.proxyUrl, tool);
+            if(proxyConfig.proxyUsername) {
+                argument("proxyUser", proxyConfig.proxyUsername, tool);
+            }
+            if(proxyConfig.proxyPassword){
+                argument("proxyPass", proxyConfig.proxyPassword, tool);
+            }
+        }
+    }
+
+    return includeAdditionalArguments(value, tool);
+});
+
+export const includeAdditionalArguments = curry((value: string, tool: ToolRunner) => {
     return tool.line(value);
 });
 


### PR DESCRIPTION
This PR exists to address #134.

As part of investigating this issue I found out that is [not possible to retrieve the timeout value at execution time](https://github.com/microsoft/azure-pipelines-task-lib/issues/796), hence I have decided to just make that timeout time quite large.

Also as part of this PR I decided to also include the proxy configuration which was not being passed into the `octo` CLI.


