### PR TITLE
Update the Build Url

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -8,7 +8,7 @@ on:
     branches: [ main ]
 
 env:
-  OCTOPUS_VERSION: 5.0.${{ github.run_number }}
+  OCTOPUS_VERSION: 5.1.${{ github.run_number }}
 
 jobs:
   build:

--- a/README.md
+++ b/README.md
@@ -67,6 +67,10 @@ It's highly recommended to set up two Virtual Machines running Windows Server. T
 
 To install locally, build and package the application as per the instructions above. Then install the extension by uploading it. Instructions to do this are available in Microsoft's [TFS/ADO docs](https://docs.microsoft.com/en-us/vsts/marketplace/get-tfs-extensions?view=tfs-2018#install-extensions-for-disconnected-tfs).
 
+### Local
+
+The SemVer major.minor for the package is currently controlled by the /.github/workflows/build.yml file. Update this file as part of your PR if making breaking/additive changes.
+
 #### Additional tips
 
 * TFS/ADO is accessible on port 8080 by default (this can be changed if desired) at something like the following: `http://<server name/ip>:8080/tfs/`

--- a/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
+++ b/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
@@ -66,7 +66,7 @@ export class BuildInformation {
         const buildInformation: IOctopusBuildInformation = {
             BuildEnvironment: "Azure DevOps",
             BuildNumber: environment.buildNumber,
-            BuildUrl: environment.teamCollectionUri.replace(/\/$/, "") + "/" + environment.projectName + "/_build/results?buildId=" + environment.buildId,
+            BuildUrl: environment.teamCollectionUri.replace(/\/$/, "") + "/" + environment.projectName + "/_build/index?buildId=" + environment.buildId,
             Branch: branch,
             VcsType: this.getVcsTypeFromProvider(environment.buildRepositoryProvider),
             VcsRoot: environment.buildRepositoryUri,

--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
@@ -44,7 +44,7 @@ async function run() {
         const buildInformation: IOctopusBuildInformation = {
             BuildEnvironment: "Azure DevOps",
             BuildNumber: environment.buildNumber,
-            BuildUrl: environment.teamCollectionUri.replace(/\/$/, "") + "/" + environment.projectName + "/_build/results?buildId=" + environment.buildId,
+            BuildUrl: environment.teamCollectionUri.replace(/\/$/, "") + "/" + environment.projectName + "/_build/index?buildId=" + environment.buildId,
             // @ts-expect-error
             Branch: branch,
             VcsType: getVcsTypeFromProvider(environment.buildRepositoryProvider),


### PR DESCRIPTION
The Build urls were originally assumed to be `https://..../results?buildId=1234`. However, the `results` part of that route only works in ADO itself, not in TFS 2018.

This PR updates the plugin to use `index` instead, which should display the correct result on both ADO and TFS.