### PR TITLE
Steps shouldn't have been marked as deprecated

### DIFF
--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
@@ -26,7 +26,7 @@ export interface IOctopusBuildInformationCommit {
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const environment = getVstsEnvironmentVariables();
         const vstsConnection = createVstsConnection(environment);
 

--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/task.json
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/task.json
@@ -1,13 +1,11 @@
 ﻿{
     "id": "b1861ef4-b62e-40c1-bcb0-be00d454a8a7",
     "name": "OctopusMetadata",
-    "friendlyName": "[DEPRECATED] Push Package Build Information to Octopus",
-    "description": "This task is deprecated, please use latest version instead. Collect information related to the build, including work items from commit messages, and push to your Octopus Deploy Server.",
+    "friendlyName": "Push Package Build Information to Octopus",
+    "description": "There is a later version of this task, we recommend using the latest version. Collect information related to the build, including work items from commit messages, and push to your Octopus Deploy Server.",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Package",
-    "visibility": [
-        "Build"
-    ],
+    "visibility": ["Build"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
@@ -90,7 +88,7 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Push Package Build Information to Octopus",
+    "instanceNameFormat": "Push Package Build Information to Octopus",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
@@ -8,7 +8,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const environmentVariables = getVstsEnvironmentVariables();
         const vstsConnection = createVstsConnection(environmentVariables);
         const connection = getDefaultOctopusConnectionDetailsOrThrow();

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/task.json
@@ -1,14 +1,11 @@
 ﻿{
     "id": "4E131B60-5532-4362-95B6-7C67D9841B4F",
     "name": "OctopusCreateRelease",
-    "friendlyName": "[DEPRECATED] Create Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Create a Release in Octopus Deploy",
+    "friendlyName": "Create Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Create a Release in Octopus Deploy",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
@@ -260,7 +257,7 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Create Octopus Release",
+    "instanceNameFormat": "Create Octopus Release",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Deploy/DeployV4/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV4/index.ts
@@ -7,7 +7,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Deploy/DeployV4/task.json
+++ b/source/tasksLegacy/Deploy/DeployV4/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "8ca1d96a-151d-44b7-bc4f-9251e2ea6971",
     "name": "OctopusDeployRelease",
-    "friendlyName": "[DEPRECATED] Deploy Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Deploy an Octopus Deploy Release",
+    "friendlyName": "Deploy Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Deploy an Octopus Deploy Release",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
         "Minor": 3,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -99,7 +95,7 @@
             "required": false,
             "helpMarkDown": "If checked, the build process will only succeed if the deployment is successful."
         },
-         {
+        {
             "name": "DeployForTenants",
             "type": "pickList",
             "label": "Tenant(s)",
@@ -177,7 +173,7 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Deploy Octopus Release",
+    "instanceNameFormat": "Deploy Octopus Release",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
+++ b/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
@@ -6,7 +6,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
         const args = tasks.getInput("args", false);
         const command = tasks.getInput("command", true);

--- a/source/tasksLegacy/OctoCli/OctoCliV4/task.json
+++ b/source/tasksLegacy/OctoCli/OctoCliV4/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "25fee290-e578-491b-b1db-dbc3980df1d0",
     "name": "OctoCli",
-    "friendlyName": "[DEPRECATED] Invoke Octopus CLI command",
-    "description": "This task is deprecated, please use latest version instead. Invoke an Octopus CLI command",
+    "friendlyName": "Invoke Octopus CLI command",
+    "description": "There is a later version of this task, we recommend using the latest version. Invoke an Octopus CLI command",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Tool",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
         "Minor": 3,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -51,7 +47,7 @@
             "helpMarkDown": "The arguments to use for the command."
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Invoke an Octopus CLI command",
+    "instanceNameFormat": "Invoke an Octopus CLI command",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Promote/PromoteV4/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV4/index.ts
@@ -7,7 +7,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Promote/PromoteV4/task.json
+++ b/source/tasksLegacy/Promote/PromoteV4/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "1627fcfe-f292-4904-adac-26cfb14bdb07",
     "name": "OctopusPromote",
-    "friendlyName": "[DEPRECATED] Promote Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Promote an Octopus release from one environment to another",
+    "friendlyName": "Promote Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Promote an Octopus release from one environment to another",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
         "Minor": 3,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -190,7 +186,7 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Promote Project in Octopus",
+    "instanceNameFormat": "Promote Project in Octopus",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Push/PushV4/index.ts
+++ b/source/tasksLegacy/Push/PushV4/index.ts
@@ -8,7 +8,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Push/PushV4/task.json
+++ b/source/tasksLegacy/Push/PushV4/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "d05ad9a2-5d9e-4a1c-a887-14034334d6f2",
     "name": "OctopusPush",
-    "friendlyName": "[DEPRECATED] Push Package(s) to Octopus",
-    "description": "This task is deprecated, please use latest version instead. Push your NuGet or Zip package to your Octopus Deploy Server",
+    "friendlyName": "Push Package(s) to Octopus",
+    "description": "There is a later version of this task, we recommend using the latest version. Push your NuGet or Zip package to your Octopus Deploy Server",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Package",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 4,
         "Minor": 3,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -84,7 +80,7 @@
             "resultTemplate": "{\"Value\":\"{{{Id}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Push Packages to Octopus",
+    "instanceNameFormat": "Push Packages to Octopus",
     "execution": {
         "Node10": {
             "target": "index.js"


### PR DESCRIPTION
The V4 steps had been marked as deprecated, which isn't quite right. There are newer steps available, and we do recommend using those, but V4 steps will continue to work as is if that's what users want to do.

The primary reason to move to the V5 steps is to get away from the auto download issues with the way the V4 steps detected the CLI version to automatically install. The new installer step allows better control of which SemVer boundaries a user want to lock to.

This PR changes the wording on the tasks and log messages, away from "deprecated" to just explaining that there are new versions of the tasks available.