### PR TITLE
Removed the deprecation notices from the v3 steps.

### DIFF
--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
@@ -8,7 +8,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const environmentVariables = getVstsEnvironmentVariables();
         const vstsConnection = createVstsConnection(environmentVariables);
         const octoConnection = getDefaultOctopusConnectionDetailsOrThrow();

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "4E131B60-5532-4362-95B6-7C67D9841B4F",
     "name": "OctopusCreateRelease",
-    "friendlyName": "[DEPRECATED] Create Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Create a Release in Octopus Deploy",
+    "friendlyName": "Create Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Create a Release in Octopus Deploy",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 3,
         "Minor": 1,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -218,7 +214,7 @@
             "resultTemplate": "{\"Value\":\"{{{Name}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Create Octopus Release: $(ProjectName)",
+    "instanceNameFormat": "Create Octopus Release: $(ProjectName)",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Deploy/DeployV3/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV3/index.ts
@@ -7,7 +7,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Deploy/DeployV3/task.json
+++ b/source/tasksLegacy/Deploy/DeployV3/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "8ca1d96a-151d-44b7-bc4f-9251e2ea6971",
     "name": "OctopusDeployRelease",
-    "friendlyName": "[DEPRECATED] Deploy Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Deploy an Octopus Deploy Release",
+    "friendlyName": "Deploy Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Deploy an Octopus Deploy Release",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 3,
         "Minor": 1,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -99,7 +95,7 @@
             "required": false,
             "helpMarkDown": "If checked, the build process will only succeed if the deployment is successful."
         },
-         {
+        {
             "name": "DeployForTenants",
             "type": "pickList",
             "label": "Tenant(s)",
@@ -159,7 +155,7 @@
             "resultTemplate": "{\"Value\":\"{{{Name}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Deploy Octopus Release: $(Project) to $(Environments)",
+    "instanceNameFormat": "Deploy Octopus Release: $(Project) to $(Environments)",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Promote/PromoteV3/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV3/index.ts
@@ -7,7 +7,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Promote/PromoteV3/task.json
+++ b/source/tasksLegacy/Promote/PromoteV3/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "1627fcfe-f292-4904-adac-26cfb14bdb07",
     "name": "OctopusPromote",
-    "friendlyName": "[DEPRECATED] Promote Octopus Release",
-    "description": "This task is deprecated, please use latest version instead. Promote an Octopus release from one environment to another",
+    "friendlyName": "Promote Octopus Release",
+    "description": "There is a later version of this task, we recommend using the latest version. Promote an Octopus release from one environment to another",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Deploy",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 3,
         "Minor": 1,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -168,7 +164,7 @@
             "resultTemplate": "{\"Value\":\"{{{Name}}}\",\"DisplayValue\":\"{{{Name}}}\"}"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Promote $(Project) from $(From) to $(To)",
+    "instanceNameFormat": "Promote $(Project) from $(From) to $(To)",
     "execution": {
         "Node10": {
             "target": "index.js"

--- a/source/tasksLegacy/Push/PushV3/index.ts
+++ b/source/tasksLegacy/Push/PushV3/index.ts
@@ -8,7 +8,7 @@ import os from "os";
 
 async function run() {
     try {
-        tasks.warning("This task is deprecated, please use latest version instead.");
+        tasks.warning("There is a later version of this task, we recommend using the latest version.");
         const connection = getDefaultOctopusConnectionDetailsOrThrow();
 
         const space = tasks.getInput("Space");

--- a/source/tasksLegacy/Push/PushV3/task.json
+++ b/source/tasksLegacy/Push/PushV3/task.json
@@ -1,21 +1,17 @@
 ﻿{
     "id": "d05ad9a2-5d9e-4a1c-a887-14034334d6f2",
     "name": "OctopusPush",
-    "friendlyName": "[DEPRECATED] Push Package(s) to Octopus",
-    "description": "This task is deprecated, please use latest version instead. Push your NuGet or Zip package to your Octopus Deploy Server",
+    "friendlyName": "Push Package(s) to Octopus",
+    "description": "There is a later version of this task, we recommend using the latest version. Push your NuGet or Zip package to your Octopus Deploy Server",
     "helpMarkDown": "set-by-pack.ps1",
     "category": "Package",
-    "visibility": [
-        "Build",
-        "Release"
-    ],
+    "visibility": ["Build", "Release"],
     "author": "Octopus Deploy",
     "version": {
         "Major": 3,
         "Minor": 1,
         "Patch": 0
     },
-    "deprecated": true,
     "demands": [],
     "minimumAgentVersion": "2.144.0",
     "groups": [
@@ -71,7 +67,7 @@
             "groupName": "advanced"
         }
     ],
-    "instanceNameFormat": "[DEPRECATED] Push Packages to Octopus",
+    "instanceNameFormat": "Push Packages to Octopus",
     "execution": {
         "Node10": {
             "target": "index.js"


### PR DESCRIPTION
Along the lines of #238, the v3 are out of date but are not being deprecated. I.e. there are no plans to actually remove them.

Changing this wording will hopefully remove confusion.

Fixes #239 