### PR TITLE
Added node-prune back into the pipeline to reduce the package size

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,6 +34,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'npm'
+      
       - name: Build
         id: build
         run: |
@@ -63,6 +64,7 @@ jobs:
         with:
           node-version: '16'
           cache: 'npm'
+
       - name: Test
         run: |
           npm install
@@ -92,6 +94,11 @@ jobs:
           node-version: '16'
           cache: 'npm'
 
+      - name: Install Go
+        uses: actions/setup-go@v2
+        with:
+          go-version: '^1.17.7'
+          
       - name: Embed octo portable
         run: |
           pwsh ./embed-octo.ps1

--- a/pack.ps1
+++ b/pack.ps1
@@ -60,6 +60,12 @@ function SetupTaskDependencies($workingDirectory) {
     mkdir "$tempPath/node_modules"
     & npm install --prefix $tempPath azure-pipelines-task-lib azure-pipelines-tool-lib
     & npm dedup --prefix $tempPath
+    & go install github.com/tj/node-prune@latest
+
+    $goPath = go env GOPATH
+    $command = "$goPath/bin/node-prune"
+
+    Invoke-Expression "$command $tempPath/node_modules"
 
     $taskManifestFiles = Get-ChildItem $workingDirectory -Include "task.json" -Recurse
 


### PR DESCRIPTION
We had removed the use of `node-prune`, under the assumption that npm should be doing a prune by default. It's prune doesn't seem to be aggresive enough to keep the package size under the Azure DevOps vsix size limit though, so we've reverted that change in the build pipeline.

Fixes #243 