### PR TITLE
Include the step identifier in the user agent string

### DIFF
--- a/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
+++ b/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
@@ -93,7 +93,7 @@ export class BuildInformation {
             this.tool.arg(["--package-id", item]);
         }
 
-        await executeTask(this.tool, "(build-information:push:v5)", this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
+        await executeTask(this.tool, "(build-information;push;v5)", this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
     }
 
     private getVcsTypeFromProvider = (buildRepositoryProvider: string) => {

--- a/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
+++ b/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
@@ -93,7 +93,7 @@ export class BuildInformation {
             this.tool.arg(["--package-id", item]);
         }
 
-        await executeTask(this.tool, this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
+        await executeTask(this.tool, "push-build-information", this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
     }
 
     private getVcsTypeFromProvider = (buildRepositoryProvider: string) => {

--- a/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
+++ b/source/tasks/BuildInformation/BuildInformationV5/buildInformation.ts
@@ -93,7 +93,7 @@ export class BuildInformation {
             this.tool.arg(["--package-id", item]);
         }
 
-        await executeTask(this.tool, "push-build-information", this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
+        await executeTask(this.tool, "(build-information:push:v5)", this.connection, "Build information successfully pushed.", "Failed to push build information.", additionalArguments);
     }
 
     private getVcsTypeFromProvider = (buildRepositoryProvider: string) => {

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
@@ -39,6 +39,6 @@ export class CreateRelease {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, "create-release", this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
+        await executeTask(this.tool, "(release:create:v5)", this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
     }
 }

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
@@ -39,6 +39,6 @@ export class CreateRelease {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
+        await executeTask(this.tool, "create-release", this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
     }
 }

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV5/createRelease.ts
@@ -39,6 +39,6 @@ export class CreateRelease {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, "(release:create:v5)", this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
+        await executeTask(this.tool, "(release;create;v5)", this.connection, "Create release succeeded.", "Failed to create release.", additionalArguments);
     }
 }

--- a/source/tasks/Deploy/DeployV5/deploy.ts
+++ b/source/tasks/Deploy/DeployV5/deploy.ts
@@ -31,9 +31,9 @@ export class Deploy {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        let stepIdentifier = "deploy-release";
+        let stepIdentifier = "(release:deploy:v5)";
         if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "deploy-release-tenanted";
+            stepIdentifier = "(release:deploy-tenanted:v5)";
         }
 
         await executeTask(this.tool, stepIdentifier, this.connection, "Deployment succeeded.", "Failed to deploy release.", additionalArguments);

--- a/source/tasks/Deploy/DeployV5/deploy.ts
+++ b/source/tasks/Deploy/DeployV5/deploy.ts
@@ -31,6 +31,11 @@ export class Deploy {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, this.connection, "Deployment succeeded.", "Failed to deploy release.", additionalArguments);
+        let stepIdentifier = "deploy-release";
+        if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
+            stepIdentifier = "deploy-release-tenanted";
+        }
+
+        await executeTask(this.tool, stepIdentifier, this.connection, "Deployment succeeded.", "Failed to deploy release.", additionalArguments);
     }
 }

--- a/source/tasks/Deploy/DeployV5/deploy.ts
+++ b/source/tasks/Deploy/DeployV5/deploy.ts
@@ -31,9 +31,9 @@ export class Deploy {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        let stepIdentifier = "(release:deploy:v5)";
+        let stepIdentifier = "(release;deploy;v5)";
         if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "(release:deploy-tenanted:v5)";
+            stepIdentifier = "(release;deploy-tenanted;v5)";
         }
 
         await executeTask(this.tool, stepIdentifier, this.connection, "Deployment succeeded.", "Failed to deploy release.", additionalArguments);

--- a/source/tasks/OctoCli/OctoCliV5/octoCli.ts
+++ b/source/tasks/OctoCli/OctoCliV5/octoCli.ts
@@ -7,6 +7,6 @@ export class OctoCli {
 
     public async run(args: string | undefined) {
         this.tool.arg(this.command);
-        await executeTask(this.tool, "(cli:run:v5)", this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
+        await executeTask(this.tool, "(cli;run;v5)", this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
     }
 }

--- a/source/tasks/OctoCli/OctoCliV5/octoCli.ts
+++ b/source/tasks/OctoCli/OctoCliV5/octoCli.ts
@@ -7,6 +7,6 @@ export class OctoCli {
 
     public async run(args: string | undefined) {
         this.tool.arg(this.command);
-        await executeTask(this.tool, this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
+        await executeTask(this.tool, "run-cli", this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
     }
 }

--- a/source/tasks/OctoCli/OctoCliV5/octoCli.ts
+++ b/source/tasks/OctoCli/OctoCliV5/octoCli.ts
@@ -7,6 +7,6 @@ export class OctoCli {
 
     public async run(args: string | undefined) {
         this.tool.arg(this.command);
-        await executeTask(this.tool, "run-cli", this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
+        await executeTask(this.tool, "(cli:run:v5)", this.connection, "Succeeded executing octo command.", "Failed to execute octo command.", args);
     }
 }

--- a/source/tasks/Promote/PromoteV5/promote.ts
+++ b/source/tasks/Promote/PromoteV5/promote.ts
@@ -22,6 +22,6 @@ export class Promote {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, "promote-release", this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
+        await executeTask(this.tool, "(release:promote:v5)", this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
     }
 }

--- a/source/tasks/Promote/PromoteV5/promote.ts
+++ b/source/tasks/Promote/PromoteV5/promote.ts
@@ -22,6 +22,6 @@ export class Promote {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, "(release:promote:v5)", this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
+        await executeTask(this.tool, "(release;promote;v5)", this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
     }
 }

--- a/source/tasks/Promote/PromoteV5/promote.ts
+++ b/source/tasks/Promote/PromoteV5/promote.ts
@@ -22,6 +22,6 @@ export class Promote {
             this.tool.arg(["--tenantTag", item]);
         }
 
-        await executeTask(this.tool, this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
+        await executeTask(this.tool, "promote-release", this.connection, "Promote release succeeded.", "Failed to promote release.", additionalArguments);
     }
 }

--- a/source/tasks/Push/PushV5/push.ts
+++ b/source/tasks/Push/PushV5/push.ts
@@ -18,7 +18,7 @@ export class Push {
             this.tool.arg(["--package", item]);
         }
 
-        await executeTask(this.tool, this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
+        await executeTask(this.tool, "push-package", this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
     }
 
     private resolveGlobs = async (globs: string[]): Promise<string[]> => {

--- a/source/tasks/Push/PushV5/push.ts
+++ b/source/tasks/Push/PushV5/push.ts
@@ -18,7 +18,7 @@ export class Push {
             this.tool.arg(["--package", item]);
         }
 
-        await executeTask(this.tool, "push-package", this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
+        await executeTask(this.tool, "(package:push:v5)", this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
     }
 
     private resolveGlobs = async (globs: string[]): Promise<string[]> => {

--- a/source/tasks/Push/PushV5/push.ts
+++ b/source/tasks/Push/PushV5/push.ts
@@ -18,7 +18,7 @@ export class Push {
             this.tool.arg(["--package", item]);
         }
 
-        await executeTask(this.tool, "(package:push:v5)", this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
+        await executeTask(this.tool, "(package;push;v5)", this.connection, "Package(s) pushed.", "Failed to push package(s).", additionalArguments);
     }
 
     private resolveGlobs = async (globs: string[]): Promise<string[]> => {

--- a/source/tasks/Utils/octopusTasks.ts
+++ b/source/tasks/Utils/octopusTasks.ts
@@ -4,13 +4,13 @@ import { OctoServerConnectionDetails } from "./connection";
 import { connectionArguments, includeAdditionalArgumentsAndProxyConfig } from "./inputs";
 import { OctopusToolRunner, runOctopusCli } from "./tool";
 
-export async function executeTask(tool: OctopusToolRunner, connection: OctoServerConnectionDetails, successMessage: string, failureMessage: string, additionalArguments?: string | undefined) {
+export async function executeTask(tool: OctopusToolRunner, stepIdentifier: string, connection: OctoServerConnectionDetails, successMessage: string, failureMessage: string, additionalArguments?: string | undefined) {
     return executeWithSetResult(
         async () => {
             connectionArguments(connection, tool);
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments, tool);
 
-            await runOctopusCli(tool);
+            await runOctopusCli(tool, stepIdentifier);
         },
         successMessage,
         failureMessage

--- a/source/tasks/Utils/tool.ts
+++ b/source/tasks/Utils/tool.ts
@@ -2,12 +2,12 @@ import { IExecOptions } from "azure-pipelines-task-lib/toolrunner";
 import Q from "q";
 import * as tasks from "azure-pipelines-task-lib";
 
-function getExecOptions(): IExecOptions {
-    return { env: { OCTOEXTENSION: process.env.EXTENSION_VERSION, ...process.env } };
+function getExecOptions(stepIdentifier: string): IExecOptions {
+    return { env: { OCTOEXTENSION: `${process.env.EXTENSION_VERSION} ${stepIdentifier}`, ...process.env } };
 }
 
-export function runOctopusCli(tool: OctopusToolRunner) {
-    return tool.exec(getExecOptions());
+export function runOctopusCli(tool: OctopusToolRunner, stepIdentifier: string) {
+    return tool.exec(getExecOptions(stepIdentifier));
 }
 
 export interface OctopusToolRunner {

--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
@@ -81,7 +81,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "push-build-information"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
@@ -81,7 +81,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(build-information:push:v4)"))
+            .map((x) => x.launchOcto(configure, "(build-information;push;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
+++ b/source/tasksLegacy/BuildInformation/BuildInformationV4/index.ts
@@ -81,7 +81,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "push-build-information"))
+            .map((x) => x.launchOcto(configure, "(build-information:push:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
@@ -59,7 +59,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "create-release"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
@@ -59,7 +59,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(release:create:v3)"))
+            .map((x) => x.launchOcto(configure, "(release;create;v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV3/index.ts
@@ -59,7 +59,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "create-release"))
+            .map((x) => x.launchOcto(configure, "(release:create:v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
@@ -67,7 +67,7 @@ async function run() {
         configure.push(includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments));
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "create-release"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
@@ -67,7 +67,7 @@ async function run() {
         configure.push(includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments));
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "create-release"))
+            .map((x) => x.launchOcto(configure, "(release:create:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
+++ b/source/tasksLegacy/CreateOctopusRelease/CreateOctopusReleaseV4/index.ts
@@ -67,7 +67,7 @@ async function run() {
         configure.push(includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments));
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(release:create:v4)"))
+            .map((x) => x.launchOcto(configure, "(release;create;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Deploy/DeployV3/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV3/index.ts
@@ -37,8 +37,13 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
+        let stepIdentifier = "deploy-release";
+        if (deploymentForTenants.length > 0 || deployForTenantTags.length > 0) {
+            stepIdentifier = "deploy-release-tenanted";
+        }
+
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, stepIdentifier))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Deploy/DeployV3/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV3/index.ts
@@ -37,9 +37,9 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
-        let stepIdentifier = "(release:deploy:v3)";
+        let stepIdentifier = "(release;deploy;v3)";
         if (deploymentForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "(release:deploy-tenanted:v3)";
+            stepIdentifier = "(release;deploy-tenanted;v3)";
         }
 
         const code: number = await octo

--- a/source/tasksLegacy/Deploy/DeployV3/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV3/index.ts
@@ -37,9 +37,9 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
-        let stepIdentifier = "deploy-release";
+        let stepIdentifier = "(release:deploy:v3)";
         if (deploymentForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "deploy-release-tenanted";
+            stepIdentifier = "(release:deploy-tenanted:v3)";
         }
 
         const code: number = await octo

--- a/source/tasksLegacy/Deploy/DeployV4/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV4/index.ts
@@ -37,8 +37,13 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
+        let stepIdentifier = "deploy-release";
+        if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
+            stepIdentifier = "deploy-release-tenanted";
+        }
+
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, stepIdentifier))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Deploy/DeployV4/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV4/index.ts
@@ -37,9 +37,9 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
-        let stepIdentifier = "deploy-release";
+        let stepIdentifier = "(release:deploy:v4)";
         if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "deploy-release-tenanted";
+            stepIdentifier = "(release:deploy-tenanted:v4)";
         }
 
         const code: number = await octo

--- a/source/tasksLegacy/Deploy/DeployV4/index.ts
+++ b/source/tasksLegacy/Deploy/DeployV4/index.ts
@@ -37,9 +37,9 @@ async function run() {
             includeAdditionalArgumentsAndProxyConfig(connection.url, additionalArguments),
         ];
 
-        let stepIdentifier = "(release:deploy:v4)";
+        let stepIdentifier = "(release;deploy;v4)";
         if (deployForTenants.length > 0 || deployForTenantTags.length > 0) {
-            stepIdentifier = "(release:deploy-tenanted:v4)";
+            stepIdentifier = "(release;deploy-tenanted;v4)";
         }
 
         const code: number = await octo

--- a/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
+++ b/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
@@ -17,7 +17,7 @@ async function run() {
         const configure = [connectionArguments(connection), includeAdditionalArguments(args)];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "run-cli"))
+            .map((x) => x.launchOcto(configure, "(cli:run:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
+++ b/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
@@ -17,7 +17,7 @@ async function run() {
         const configure = [connectionArguments(connection), includeAdditionalArguments(args)];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(cli:run:v4)"))
+            .map((x) => x.launchOcto(configure, "(cli;run;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
+++ b/source/tasksLegacy/OctoCli/OctoCliV4/index.ts
@@ -17,7 +17,7 @@ async function run() {
         const configure = [connectionArguments(connection), includeAdditionalArguments(args)];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "run-cli"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Pack/PackV4/index.ts
+++ b/source/tasksLegacy/Pack/PackV4/index.ts
@@ -99,7 +99,7 @@ Alternatively, if NuGet package metadata is required, consider using the 'NuGet'
         const configureTool = configure(getInputs());
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configureTool, "(package:pack:v4)"))
+            .map((x) => x.launchOcto(configureTool, "(package;pack;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Pack/PackV4/index.ts
+++ b/source/tasksLegacy/Pack/PackV4/index.ts
@@ -99,7 +99,7 @@ Alternatively, if NuGet package metadata is required, consider using the 'NuGet'
         const configureTool = configure(getInputs());
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configureTool))
+            .map((x) => x.launchOcto(configureTool, "pack"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Pack/PackV4/index.ts
+++ b/source/tasksLegacy/Pack/PackV4/index.ts
@@ -99,7 +99,7 @@ Alternatively, if NuGet package metadata is required, consider using the 'NuGet'
         const configureTool = configure(getInputs());
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configureTool, "pack"))
+            .map((x) => x.launchOcto(configureTool, "(package:pack:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV3/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV3/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "promote-release"))
+            .map((x) => x.launchOcto(configure, "(release:promote:v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV3/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV3/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(release:promote:v3)"))
+            .map((x) => x.launchOcto(configure, "(release;promote;v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV3/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV3/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "promote-release"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV4/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV4/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(release:promote:v4)"))
+            .map((x) => x.launchOcto(configure, "(release;promote;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV4/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV4/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "promote-release"))
+            .map((x) => x.launchOcto(configure, "(release:promote:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Promote/PromoteV4/index.ts
+++ b/source/tasksLegacy/Promote/PromoteV4/index.ts
@@ -39,7 +39,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "promote-release"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV3/index.ts
+++ b/source/tasksLegacy/Push/PushV3/index.ts
@@ -31,7 +31,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(package:push:v3)"))
+            .map((x) => x.launchOcto(configure, "(package;push;v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV3/index.ts
+++ b/source/tasksLegacy/Push/PushV3/index.ts
@@ -31,7 +31,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "push-package"))
+            .map((x) => x.launchOcto(configure, "(package:push:v3)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV3/index.ts
+++ b/source/tasksLegacy/Push/PushV3/index.ts
@@ -31,7 +31,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "push-package"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV4/index.ts
+++ b/source/tasksLegacy/Push/PushV4/index.ts
@@ -33,7 +33,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "push-package"))
+            .map((x) => x.launchOcto(configure, "(package:push:v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV4/index.ts
+++ b/source/tasksLegacy/Push/PushV4/index.ts
@@ -33,7 +33,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure))
+            .map((x) => x.launchOcto(configure, "push-package"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Push/PushV4/index.ts
+++ b/source/tasksLegacy/Push/PushV4/index.ts
@@ -33,7 +33,7 @@ async function run() {
         ];
 
         const code: number = await octo
-            .map((x) => x.launchOcto(configure, "(package:push:v4)"))
+            .map((x) => x.launchOcto(configure, "(package;push;v4)"))
             .getOrElseL((x) => {
                 throw new Error(x);
             });

--- a/source/tasksLegacy/Utils/tool.ts
+++ b/source/tasksLegacy/Utils/tool.ts
@@ -25,20 +25,20 @@ export class OctoLauncher {
         this.runner = runner;
     }
 
-    private getExecOptions(): IExecOptions {
-        return { env: { OCTOEXTENSION: process.env.EXTENSION_VERSION, ...process.env } };
+    private getExecOptions(stepIdentifier: string): IExecOptions {
+        return { env: { OCTOEXTENSION: `${process.env.EXTENSION_VERSION} ${stepIdentifier}`, ...process.env } };
     }
 
-    public launchOcto(configurations: Array<(tool: ToolRunner) => ToolRunner>): Q.Promise<number> {
+    public launchOcto(configurations: Array<(tool: ToolRunner) => ToolRunner>, stepIdentifier: string): Q.Promise<number> {
         configureTool(configurations)(this.runner);
 
-        return this.runner.exec(this.getExecOptions());
+        return this.runner.exec(this.getExecOptions(stepIdentifier));
     }
 
-    public launchOctoSync(configurations: Array<(tool: ToolRunner) => ToolRunner>): IExecSyncResult {
+    public launchOctoSync(configurations: Array<(tool: ToolRunner) => ToolRunner>, stepIdentifier: string): IExecSyncResult {
         configureTool(configurations)(this.runner);
 
-        return this.runner.execSync(this.getExecOptions());
+        return this.runner.execSync(this.getExecOptions(stepIdentifier));
     }
 }
 

--- a/source/tasksLegacy/Utils/tool.ts
+++ b/source/tasksLegacy/Utils/tool.ts
@@ -90,7 +90,7 @@ export function getPortableOctoCommandRunner(command: string): Option<ToolRunner
 export const assertOctoVersionAcceptsIds = async function (): Promise<void> {
     const octo = await getOrInstallOctoCommandRunner("version");
     const result = octo
-        .map((x) => x.launchOctoSync([]))
+        .map((x) => x.launchOctoSync([], "version"))
         .getOrElseL((x) => {
             throw new Error(x);
         });


### PR DESCRIPTION
The current user agent string allow us to determine which versions of the Azure DevOps plugin are actively in use against Octopus instances. For those that report telemetry.

This PR extends the user agent strings to include a step identifier, which will allow us to determine which versions of which steps are actively being used.

Example of previous user agent string content
```
AzureDevOps ... octo plugin/1.2.3
```
which will now become something like
```
AzureDevOps ... octo plugin/1.2.3 create-release
```

Example from the build pipeline run on this PR's branch
![image](https://user-images.githubusercontent.com/4229735/212620532-467e30eb-93f7-462e-9344-33c6a2edafe2.png)
