### PR TITLE
updated minimum agent version for v6 steps

### DIFF
--- a/source/tasks/AwaitTask/AwaitTaskV6/task.json
+++ b/source/tasks/AwaitTask/AwaitTaskV6/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "inputs": [
         {
             "name": "OctoConnectedServiceName",

--- a/source/tasks/BuildInformation/BuildInformationV6/task.json
+++ b/source/tasks/BuildInformation/BuildInformationV6/task.json
@@ -15,7 +15,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "inputs": [
         {
             "name": "OctoConnectedServiceName",

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [ ],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "versionControl",

--- a/source/tasks/Deploy/DeployV6/task.json
+++ b/source/tasks/Deploy/DeployV6/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/DeployTenant/TenantedDeployV6/task.json
+++ b/source/tasks/DeployTenant/TenantedDeployV6/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/OctoInstaller/OctoInstallerV6/task.json
+++ b/source/tasks/OctoInstaller/OctoInstallerV6/task.json
@@ -21,7 +21,7 @@
     },
     "satisfies": ["octopus"],
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/PackNuGet/PackNuGetV6/task.json
+++ b/source/tasks/PackNuGet/PackNuGetV6/task.json
@@ -13,7 +13,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/PackZip/PackZipV6/task.json
+++ b/source/tasks/PackZip/PackZipV6/task.json
@@ -13,7 +13,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "groups": [
         {
             "name": "advanced",

--- a/source/tasks/Push/PushV6/task.json
+++ b/source/tasks/Push/PushV6/task.json
@@ -16,7 +16,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "inputs": [
         {
             "name": "OctoConnectedServiceName",

--- a/source/tasks/RunRunbook/RunRunbookV6/task.json
+++ b/source/tasks/RunRunbook/RunRunbookV6/task.json
@@ -13,7 +13,7 @@
         "Patch": 0
     },
     "demands": [],
-    "minimumAgentVersion": "2.144.0",
+    "minimumAgentVersion": "2.206.1",
     "inputs": [
         {
             "name": "OctoConnectedServiceName",


### PR DESCRIPTION
Minimum agent version should be 2.206.1 to support Node 16 as per https://github.com/microsoft/azure-pipelines-task-lib/blob/master/node/docs/minagent.md#task-execution-handler

fixes: #304 

[sc-44888]