### PR TITLE
added release notes file option for create-release v6

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
@@ -1,6 +1,9 @@
 import { Logger } from "@octopusdeploy/api-client";
 import { createCommandFromInputs } from "./inputCommandBuilder";
 import { MockTaskWrapper } from "../../Utils/MockTaskWrapper";
+import * as path from "path";
+import fs from "fs";
+import os from "os";
 
 describe("getInputCommand", () => {
     let logger: Logger;
@@ -42,6 +45,19 @@ describe("getInputCommand", () => {
         const command = createCommandFromInputs(logger, task);
         expect(command.Packages).toStrictEqual(["Baz:2.5.0", "Step1:Foo:1.0.0", "Bar:2.0.0"]);
     });
+
+    test("release notes file", async () => {
+        const tempOutDir = await fs.mkdtempSync(path.join(os.tmpdir(), "octopus_"));
+        const notesPath = path.join(tempOutDir, "notes.txt");
+
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Project", "Awesome project");
+        task.addVariableString("ReleaseNotesFile", notesPath);
+
+        fs.writeFileSync(notesPath, "this is a release note");
+        const command = createCommandFromInputs(logger, task);
+        expect(command.ReleaseNotes).toBe("this is a release note");
+    })
 
     test("duplicate variable name, variables field takes precedence", () => {
         task.addVariableString("Space", "Default");

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
@@ -57,7 +57,21 @@ describe("getInputCommand", () => {
         fs.writeFileSync(notesPath, "this is a release note");
         const command = createCommandFromInputs(logger, task);
         expect(command.ReleaseNotes).toBe("this is a release note");
-    })
+    });
+
+    test("release notes takes precedence", async () => {
+        const tempOutDir = await fs.mkdtempSync(path.join(os.tmpdir(), "octopus_"));
+        const notesPath = path.join(tempOutDir, "notes.txt");
+
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Project", "Awesome project");
+        task.addVariableString("ReleaseNotes", "inline release notes");
+        task.addVariableString("ReleaseNotesFile", notesPath);
+
+        fs.writeFileSync(notesPath, "this is a release note");
+        const command = createCommandFromInputs(logger, task);
+        expect(command.ReleaseNotes).toBe("inline release notes");
+    });
 
     test("duplicate variable name, variables field takes precedence", () => {
         task.addVariableString("Space", "Default");

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
@@ -59,7 +59,7 @@ describe("getInputCommand", () => {
         expect(command.ReleaseNotes).toBe("this is a release note");
     });
 
-    test("release notes takes precedence", async () => {
+    test("specifying both release notes and release notes file causes error", async () => {
         const tempOutDir = await fs.mkdtempSync(path.join(os.tmpdir(), "octopus_"));
         const notesPath = path.join(tempOutDir, "notes.txt");
 
@@ -69,8 +69,7 @@ describe("getInputCommand", () => {
         task.addVariableString("ReleaseNotesFile", notesPath);
 
         fs.writeFileSync(notesPath, "this is a release note");
-        const command = createCommandFromInputs(logger, task);
-        expect(command.ReleaseNotes).toBe("inline release notes");
+        expect(() => createCommandFromInputs(logger, task)).toThrowError("cannot specify ReleaseNotes and ReleaseNotesFile");
     });
 
     test("duplicate variable name, variables field takes precedence", () => {

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
@@ -3,6 +3,8 @@ import shlex from "shlex";
 import { getLineSeparatedItems } from "../../Utils/inputs";
 import { CreateReleaseCommandV1, Logger } from "@octopusdeploy/api-client";
 import { TaskWrapper } from "tasks/Utils/taskInput";
+import { isNullOrWhitespace } from "../../../tasksLegacy/Utils/inputs";
+import fs from "fs";
 
 export function createCommandFromInputs(logger: Logger, task: TaskWrapper): CreateReleaseCommandV1 {
     const packages: string[] = [];
@@ -63,6 +65,13 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         GitRef: task.getInput("GitRef"),
         GitCommit: task.getInput("GitCommit"),
     };
+
+    if (!command.ReleaseNotes) {
+        const releaseNotesFile = task.getInput("ReleaseNotesFile");
+        if (!isNullOrWhitespace(releaseNotesFile) && fs.existsSync(releaseNotesFile) && fs.lstatSync(releaseNotesFile).isFile()) {
+            command.ReleaseNotes = fs.readFileSync(releaseNotesFile).toString();
+        }
+    }
 
     logger.debug?.(JSON.stringify(command));
 

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
@@ -66,8 +66,16 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         GitCommit: task.getInput("GitCommit"),
     };
 
-    if (!command.ReleaseNotes) {
-        const releaseNotesFile = task.getInput("ReleaseNotesFile");
+    const releaseNotesFilePath = task.getInput("ReleaseNotesFile");
+
+    if (command.ReleaseNotes && releaseNotesFilePath) {
+        const message = "cannot specify ReleaseNotes and ReleaseNotesFile";
+        task.setFailure(message);
+        throw new Error(message);
+    }
+
+    if (releaseNotesFilePath) {
+        const releaseNotesFile = releaseNotesFilePath;
         if (!isNullOrWhitespace(releaseNotesFile) && fs.existsSync(releaseNotesFile) && fs.lstatSync(releaseNotesFile).isFile()) {
             command.ReleaseNotes = fs.readFileSync(releaseNotesFile).toString();
         }

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
@@ -92,7 +92,7 @@
             "label": "Release Notes",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Octopus Release notes. This field supports markdown. To include newlines, you can use HTML linebreaks."
+            "helpMarkDown": "Octopus Release notes. This field supports markdown. To include newlines, you can use HTML linebreaks. Can only specify this if 'ReleaseNotesFile' is not supplied."
         },
         {
             "name": "ReleaseNotesFile",
@@ -100,7 +100,7 @@
             "label": "Release Notes File",
             "defaultValue": "",
             "required": false,
-            "helpMarkDown": "Octopus Release notes file. Path to a file that contains the release notes. Supports markdown. Will only be used if the Release Notes field is empty."
+            "helpMarkDown": "Octopus Release notes file. Path to a file that contains the release notes. Supports markdown. Can only specify this if 'ReleaseNotes' is not supplied."
         },
         {
             "name": "GitRef",

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
@@ -95,6 +95,14 @@
             "helpMarkDown": "Octopus Release notes. This field supports markdown. To include newlines, you can use HTML linebreaks."
         },
         {
+            "name": "ReleaseNotesFile",
+            "type": "string",
+            "label": "Release Notes File",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Octopus Release notes file. Path to a file that contains the release notes. Supports markdown. Will only be used if the Release Notes field is empty."
+        },
+        {
             "name": "GitRef",
             "type": "string",
             "label": "Git Reference",


### PR DESCRIPTION
fixes #310 

[sc-47628]

```yaml
- task: OctopusCreateRelease@6
  inputs:
    OctoConnectedServiceName: 'octo'
    Space: 'Default'
    Project: 'project 2'
    ReleaseNotesFile: C:\Octopus\ha2\Logs\OctopusServer.txt
```

<img width="1271" alt="image" src="https://user-images.githubusercontent.com/5336529/235607902-50d394fe-8287-4028-9b73-036a30e1126a.png">


Specifying both release notes and release notes file throws and error

```yaml
- task: OctopusCreateRelease@6
  inputs:
    OctoConnectedServiceName: 'octo'
    Space: 'Default'
    Project: 'project 2'
    ReleaseNotes: "this is a release note"
    ReleaseNotesFile: C:\Octopus\ha2\Logs\OctopusServer.txt
```

<img width="562" alt="image" src="https://user-images.githubusercontent.com/5336529/236112401-3290c51e-231b-41c6-b5ba-ff24527a4b5c.png">
