### PR TITLE
Read releases.json from raw.githubusercontent to avoid rate limiting

### DIFF
--- a/source/tasks/OctoInstaller/OctoInstallerV6/downloadEndpointRetriever.test.ts
+++ b/source/tasks/OctoInstaller/OctoInstallerV6/downloadEndpointRetriever.test.ts
@@ -41,7 +41,7 @@ describe("OctopusInstaller", () => {
 
         const app = express();
 
-        app.get("/repos/OctopusDeploy/cli/releases", (_, res) => {
+        app.get("/OctopusDeploy/cli/main/releases.json", (_, res) => {
             const latestToolsPayload = `[
                 {
                     "tag_name": "v7.4.1",
@@ -94,7 +94,7 @@ describe("OctopusInstaller", () => {
         });
 
         const address = server.address() as AddressInfo;
-        releasesUrl = `http://localhost:${address.port}/repos/OctopusDeploy/cli/releases`;
+        releasesUrl = `http://localhost:${address.port}/OctopusDeploy/cli/main/releases.json`;
     });
 
     afterEach(async () => {

--- a/source/tasks/OctoInstaller/OctoInstallerV6/index.ts
+++ b/source/tasks/OctoInstaller/OctoInstallerV6/index.ts
@@ -22,7 +22,7 @@ async function run() {
             },
         };
 
-        new Installer("https://api.github.com/repos/OctopusDeploy/cli/releases", os.platform(), os.arch(), logger).run(version);
+        new Installer("https://raw.githubusercontent.com/OctopusDeploy/cli/main/releases.json", os.platform(), os.arch(), logger).run(version);
     } catch (error: unknown) {
         if (error instanceof Error) {
             tasks.setResult(tasks.TaskResult.Failed, `"Failed to execute pack. ${error.message}${os.EOL}${error.stack}`, true);

--- a/source/tasks/OctoInstaller/OctoInstallerV6/task.json
+++ b/source/tasks/OctoInstaller/OctoInstallerV6/task.json
@@ -35,7 +35,7 @@
             "type": "string",
             "label": "Octopus CLI Version",
             "required": true,
-            "helpMarkDown": "Specify version of Octopus CLI to install.<br/>Versions can be given in the following formats<li>`1.*` => Install latest in major version.</li><li>`7.3.*` => Install latest in major and minor version.</li><li>`8.0.1` => Install exact version.</li><li>`*` => Install whatever is latest.</li><br/>Find the value of `version` for installing Octopus CLI, from the [this link](https://github.com/OctopusDeploy/cli/releases)."
+            "helpMarkDown": "Specify version of Octopus CLI to install.<br/>Versions can be given in the following formats<li>`1.*` => Install latest in major version.</li><li>`7.3.*` => Install latest in major and minor version.</li><li>`8.0.1` => Install exact version.</li><li>`*` => Install whatever is latest.</li><br/>Find the value of `version` for installing Octopus CLI, from the [this link](https://raw.githubusercontent.com/OctopusDeploy/cli/main/releases.json)."
         }
     ],
     "instanceNameFormat": "Install Octopus CLI tool version $(version)",


### PR DESCRIPTION
Customers are being rate-limited when using the Install Octopus CLI GitHub Action, to avoid this entirely and avoid the dependency on an authenticated token, we've opted to store releases in the repository itself

Read releases from the non-rate limited releases list stored in the repository at`https://raw.githubusercontent.com/OctopusDeploy/cli/main/releases.json`. This change is to be merged following https://github.com/OctopusDeploy/cli/pull/228/files

[[sc-41298]](https://app.shortcut.com/octopusdeploy/story/41298/cli-installer-for-gha-actions-and-octotfs-is-hitting-github-api-limits)