### PR TITLE
Pin azure pipeline dependency versions

### DIFF
--- a/pack.ps1
+++ b/pack.ps1
@@ -58,7 +58,7 @@ function SetupTaskDependencies($workingDirectory) {
     $tempPath = "$basePath/modules";
 
     mkdir "$tempPath/node_modules"
-    & npm install --prefix $tempPath azure-pipelines-task-lib azure-pipelines-tool-lib
+    & npm install --prefix $tempPath azure-pipelines-task-lib@4.3.1 azure-pipelines-tool-lib@2.0.4
     & npm dedup --prefix $tempPath
     & go install github.com/tj/node-prune@latest
 


### PR DESCRIPTION
[SC-70520]
# Summary
In versions `> 6.0.599` the node_modules grew too large due to the `azure-pipelines-tool-lib` depending on `^4.1.0` of `azure-pipelines-task-lib` that ended up installing version `4.9.1` that had more dependencies specifically `deasync`

Because the versions of these packages isn't defined in the package.json and rather they are just installed in the pack script without a targeted version they end up just using the latest version.

# Results
- Pin azure-pipelines-task-lib and azure-pipelines-tool-lib in `pack.ps1` to last known deployable versions

Before version pin artifact size: `147.3 MB`
After version pin artifact size: `33.7 MB`