### PR TITLE
Bump api-client to version 3.3.0

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@octopusdeploy/api-client": "^3.0.7",
+        "@octopusdeploy/api-client": "^3.3.0",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "3.3.1",
         "azure-pipelines-tool-lib": "1.3.2",
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@octopusdeploy/api-client": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.0.7.tgz",
-      "integrity": "sha512-6+6/+ARTqldNVwTZGfIvPMX0ZvELo2HRSbm97VaFxFZPu8PWJOzS9yCwfugta0MWRNpPNOVjjC5wd0joSTgC+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.3.0.tgz",
+      "integrity": "sha512-OCvBBKY+ZJzt5FQRgyVZIxxHCUqvLMjpnuQ19J9nyB0Gsa4YOyMrO4u397zRN/WtnPkCzQk2K7P+x0sF+lJGFQ==",
       "dependencies": {
         "adm-zip": "^0.5.9",
         "axios": "^1.2.1",
@@ -7917,9 +7917,9 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "3.0.7",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.0.7.tgz",
-      "integrity": "sha512-6+6/+ARTqldNVwTZGfIvPMX0ZvELo2HRSbm97VaFxFZPu8PWJOzS9yCwfugta0MWRNpPNOVjjC5wd0joSTgC+Q==",
+      "version": "3.3.0",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.3.0.tgz",
+      "integrity": "sha512-OCvBBKY+ZJzt5FQRgyVZIxxHCUqvLMjpnuQ19J9nyB0Gsa4YOyMrO4u397zRN/WtnPkCzQk2K7P+x0sF+lJGFQ==",
       "requires": {
         "adm-zip": "^0.5.9",
         "axios": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
-    "@octopusdeploy/api-client": "^3.0.7",
+    "@octopusdeploy/api-client": "^3.3.0",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "3.3.1",
     "azure-pipelines-tool-lib": "1.3.2",


### PR DESCRIPTION
Bump to v3.3.0 of the api-client to fix issues with unicode characters in file names for packaging steps.