### PR TITLE
chore: bump api-client.ts to version 3.4.1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -60,7 +60,7 @@ jobs:
       checks: write
     strategy:
       matrix:
-        os: [windows-2022, ubuntu-20.04, macos-11]
+        os: [windows-2022, ubuntu-20.04, macos-12]
     steps:
       - uses: actions/checkout@v3
       - name: Use Node.js

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@octopusdeploy/api-client": "^3.3.0",
+        "@octopusdeploy/api-client": "^3.4.1",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "3.3.1",
         "azure-pipelines-tool-lib": "1.3.2",
@@ -1131,9 +1131,10 @@
       }
     },
     "node_modules/@octopusdeploy/api-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.3.0.tgz",
-      "integrity": "sha512-OCvBBKY+ZJzt5FQRgyVZIxxHCUqvLMjpnuQ19J9nyB0Gsa4YOyMrO4u397zRN/WtnPkCzQk2K7P+x0sF+lJGFQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.4.1.tgz",
+      "integrity": "sha512-j6FRgDNzc6AQoT3CAguYLWxoMR4W5TKCT1BCPpqjEN9mknmdMSKfYORs3djn/Yj/BhqtITTydDpBoREbzKY5+g==",
+      "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
         "axios": "^1.2.1",
@@ -7917,9 +7918,9 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "3.3.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.3.0.tgz",
-      "integrity": "sha512-OCvBBKY+ZJzt5FQRgyVZIxxHCUqvLMjpnuQ19J9nyB0Gsa4YOyMrO4u397zRN/WtnPkCzQk2K7P+x0sF+lJGFQ==",
+      "version": "3.4.1",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.4.1.tgz",
+      "integrity": "sha512-j6FRgDNzc6AQoT3CAguYLWxoMR4W5TKCT1BCPpqjEN9mknmdMSKfYORs3djn/Yj/BhqtITTydDpBoREbzKY5+g==",
       "requires": {
         "adm-zip": "^0.5.9",
         "axios": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
-    "@octopusdeploy/api-client": "^3.3.0",
+    "@octopusdeploy/api-client": "^3.4.1",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "3.3.1",
     "azure-pipelines-tool-lib": "1.3.2",


### PR DESCRIPTION
Updates `api-client.ts` version to 3.4.1 which now throws an error when a build info push fails.