### PR TITLE
Robe/upload artifact upgrade

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -88,7 +88,7 @@ jobs:
     if: github.event_name == 'release' || (github.actor != 'dependabot[bot]' && github.actor != 'dependabot-preview[bot]')
     steps:
       - uses: actions/checkout@v3
-      - uses: actions/download-artifact@v3
+      - uses: actions/download-artifact@v4
         with:
           name: dist
           path: dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -45,7 +45,7 @@ jobs:
           npm ci
           npm run build -- --extensionVersion $PACKAGE_VERSION
           echo "::set-output name=package_version::$PACKAGE_VERSION"
-      - uses: actions/upload-artifact@v3
+      - uses: actions/upload-artifact@v4
         with:
           name: dist
           path: dist/


### PR DESCRIPTION
upload-artifact@v3 is being [deprecated](https://github.blog/changelog/2024-04-16-deprecation-notice-v3-of-the-artifact-actions/)