### PR TITLE
Support escaped colon in variables

### DIFF
--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
@@ -60,6 +60,33 @@ describe("getInputCommand", () => {
         expect(command.Variables).toStrictEqual({ var1: "value1", var2: "value2" });
     });
 
+    test("handles escaped colons in variable names", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Variables", "Test\\:Variable: Testing3");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "Test project");
+        task.addVariableString("ReleaseNumber", "1.0.0");
+        task.addVariableString("DeployForTenants", "Tenant 1");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.Variables).toStrictEqual({ "Test:Variable": "Testing3" });
+    });
+
+    test("handles multiple variables with escaped and unescaped colons", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Variables", "Long\\:Variable\\:Name: Value123\nTest\\:Variable: Value: With: Colons");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "Test project");
+        task.addVariableString("ReleaseNumber", "1.0.0");
+        task.addVariableString("DeployForTenants", "Tenant 1");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.Variables).toStrictEqual({ 
+            "Long:Variable:Name": "Value123",
+            "Test:Variable": "Value: With: Colons"
+        });
+    });
+    
     test("multiline environments", () => {
         task.addVariableString("Space", "Default");
         task.addVariableString("Environments", "dev, test\nprod");

--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
@@ -1,6 +1,6 @@
 import commandLineArgs from "command-line-args";
 import shlex from "shlex";
-import { getLineSeparatedItems } from "../../Utils/inputs";
+import { getLineSeparatedItems, parseVariableString } from "../../Utils/inputs";
 import { CreateDeploymentUntenantedCommandV1, Logger, PromptedVariableValues } from "@octopusdeploy/api-client";
 import { TaskWrapper } from "tasks/Utils/taskInput";
 
@@ -22,13 +22,13 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     }
 
     const variablesField = task.getInput("Variables");
-    logger.debug?.("Variables:" + variablesField);
+    logger.debug?.("Variables: " + variablesField);
     if (variablesField) {
         const variables = getLineSeparatedItems(variablesField).map((p) => p.trim()) || undefined;
         if (variables) {
             for (const variable of variables) {
-                const variableMap = variable.split(":").map((x) => x.trim());
-                variablesMap[variableMap[0]] = variableMap[1];
+                const [name, value] = parseVariableString(variable);
+                variablesMap[name] = value;
             }
         }
     }

--- a/source/tasks/DeployTenant/TenantedDeployV6/inputCommandBuilder.test.ts
+++ b/source/tasks/DeployTenant/TenantedDeployV6/inputCommandBuilder.test.ts
@@ -65,6 +65,33 @@ describe("getInputCommand", () => {
         expect(command.Variables).toStrictEqual({ var1: "value1", var2: "value2" });
     });
 
+    test("handles escaped colons in variable names", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Variables", "Test\\:Variable: Testing3");
+        task.addVariableString("Environment", "dev");
+        task.addVariableString("Project", "Test project");
+        task.addVariableString("ReleaseNumber", "1.0.0");
+        task.addVariableString("DeployForTenants", "Tenant 1");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.Variables).toStrictEqual({ "Test:Variable": "Testing3" });
+    });
+
+    test("handles multiple variables with escaped and unescaped colons", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Variables", "Long\\:Variable\\:Name: Value123\nTest\\:Variable: Value: With: Colons");
+        task.addVariableString("Environment", "dev");
+        task.addVariableString("Project", "Test project");
+        task.addVariableString("ReleaseNumber", "1.0.0");
+        task.addVariableString("DeployForTenants", "Tenant 1");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.Variables).toStrictEqual({ 
+            "Long:Variable:Name": "Value123",
+            "Test:Variable": "Value: With: Colons"
+        });
+    });
+    
     test("validate tenants and tags", () => {
         task.addVariableString("Space", "Default");
         task.addVariableString("Project", "project 1");

--- a/source/tasks/DeployTenant/TenantedDeployV6/inputCommandBuilder.ts
+++ b/source/tasks/DeployTenant/TenantedDeployV6/inputCommandBuilder.ts
@@ -1,6 +1,6 @@
 import commandLineArgs from "command-line-args";
 import shlex from "shlex";
-import { getLineSeparatedItems } from "../../Utils/inputs";
+import { getLineSeparatedItems, parseVariableString } from "../../Utils/inputs";
 import { CreateDeploymentTenantedCommandV1, Logger, PromptedVariableValues } from "@octopusdeploy/api-client";
 import { TaskWrapper } from "tasks/Utils/taskInput";
 
@@ -32,8 +32,8 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         const variables = getLineSeparatedItems(variablesField).map((p) => p.trim()) || undefined;
         if (variables) {
             for (const variable of variables) {
-                const variableMap = variable.split(":").map((x) => x.trim());
-                variablesMap[variableMap[0]] = variableMap[1];
+                const [name, value] = parseVariableString(variable);
+                variablesMap[name] = value;
             }
         }
     }

--- a/source/tasks/Utils/inputs.ts
+++ b/source/tasks/Utils/inputs.ts
@@ -12,6 +12,34 @@ export function getLineSeparatedItems(value: string): Array<string> {
     return value ? value.split(/[\r\n]+/g).map((x) => x.trim()) : [];
 }
 
+export function parseVariableString(input: string): [string, string] {
+    let escapeNext = false;
+    let colonIndex = -1;
+    
+    for (let i = 0; i < input.length; i++) {
+        if (input[i] === '\\' && !escapeNext) {
+            escapeNext = true;
+            continue;
+        }
+        
+        if (input[i] === ':' && !escapeNext) {
+            colonIndex = i;
+            break;
+        }
+        
+        escapeNext = false;
+    }
+    
+    if (colonIndex === -1) {
+        throw new Error(`Invalid variable format. Expected 'name: value' but got '${input}'`);
+    }
+    
+    const variableName = input.substring(0, colonIndex).replace(/\\:/g, ':').trim();
+    const variableValue = input.substring(colonIndex + 1).trim();
+    
+    return [variableName, variableValue];
+}
+
 export function getOverwriteModeFromReplaceInput(replace: string): ReplaceOverwriteMode {
     return ReplaceOverwriteMode[replace as keyof typeof ReplaceOverwriteMode] || ReplaceOverwriteMode.false;
 }


### PR DESCRIPTION
Related to [sc-100335](https://app.shortcut.com/octopusdeploy/story/100335/sev-3-variables-that-contain-are-truncated-in-azure-devops-tasks-requested-by-dan-close)
## Support escaped colons in variable names
Fixed issue where variables containing colons in their names (e.g., "Test:Variable") were being incorrectly split. Added support for escaped colons using backslash (e.g., `Test\:Variable`) to allow colons as part of variable names while maintaining the existing delimiter functionality.
Example usage:
```yaml
Variables: 'Test\:Variable: Testing3'  # Creates variable "Test:Variable" with value "Testing3"
