### PR TITLE
Add option to ignore existing release in V6 task

### DIFF
--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/createRelease.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/createRelease.ts
@@ -10,7 +10,11 @@ export async function createReleaseFromInputs(client: Client, command: CreateRel
         const repository = new ReleaseRepository(client, command.spaceName);
         const response = await repository.create(command);
 
-        client.info(`🎉 Release ${response.ReleaseVersion} created successfully!`);
+        if (command.IgnoreIfAlreadyExists) {
+            client.info(`🎉 Release ${response.ReleaseVersion} already exists, continuing!`);
+        } else {
+            client.info(`🎉 Release ${response.ReleaseVersion} created successfully!`);
+        }
 
         task.setOutputVariable("release_number", response.ReleaseVersion);
 

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.test.ts
@@ -21,6 +21,7 @@ describe("getInputCommand", () => {
         task.addVariableString("DefaultPackageVersion", "1.0.1");
         task.addVariableString("Packages", "Step1:Foo:1.0.0\nBar:2.0.0");
         task.addVariableString("GitRef", "main");
+        task.addVariableString("IgnoreIfAlreadyExists", "true");
 
         const command = createCommandFromInputs(logger, task);
         expect(command.spaceName).toBe("Default");
@@ -30,6 +31,7 @@ describe("getInputCommand", () => {
         expect(command.PackageVersion).toBe("1.0.1");
         expect(command.Packages).toStrictEqual(["Step1:Foo:1.0.0", "Bar:2.0.0"]);
         expect(command.GitRef).toBe("main");
+        expect(command.IgnoreIfAlreadyExists).toBe(true);
 
         expect(task.lastResult).toBeUndefined();
         expect(task.lastResultMessage).toBeUndefined();

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/inputCommandBuilder.ts
@@ -64,6 +64,7 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         ReleaseNotes: task.getInput("ReleaseNotes"),
         GitRef: task.getInput("GitRef"),
         GitCommit: task.getInput("GitCommit"),
+        IgnoreIfAlreadyExists: (task.getInput("IgnoreIfAlreadyExists")?.toLowerCase() === "true"),
     };
 
     const releaseNotesFilePath = task.getInput("ReleaseNotesFile");

--- a/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
+++ b/source/tasks/CreateOctopusRelease/CreateOctopusReleaseV6/task.json
@@ -121,6 +121,15 @@
             "groupName": "versionControl"
         },
         {
+            "name": "IgnoreIfAlreadyExists",
+            "type": "boolean",
+            "label": "Ignore Existing Release",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "If enabled the step will succeed if there is already an existing release with the version number.",
+            "groupName": "additional"
+        },
+        {
             "name": "AdditionalArguments",
             "type": "string",
             "label": "Additional Arguments",


### PR DESCRIPTION
Closes #333

In the V5 task we were able to pass the `--ignoreexisting` flag allowing our pipelines to continue working even if the release already existed. In the V6 task this functionality was removed which has been blocking us from upgrading to the V6 tasks.