### PR TITLE
Add support for running Git runbooks

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@octopusdeploy/api-client": "^3.4.1",
+        "@octopusdeploy/api-client": "^3.5.1",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "3.3.1",
         "azure-pipelines-tool-lib": "1.3.2",
@@ -1131,9 +1131,9 @@
       }
     },
     "node_modules/@octopusdeploy/api-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.4.1.tgz",
-      "integrity": "sha512-j6FRgDNzc6AQoT3CAguYLWxoMR4W5TKCT1BCPpqjEN9mknmdMSKfYORs3djn/Yj/BhqtITTydDpBoREbzKY5+g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.5.1.tgz",
+      "integrity": "sha512-JKPx+L1QNjtX1txpj+0+JJR3Q5D/IwKdocih8WTGXGYNYC8jdEDgaTkPb701gD/Jzu14foNn67W4CDDBvyPZeA==",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
@@ -7918,9 +7918,9 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "3.4.1",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.4.1.tgz",
-      "integrity": "sha512-j6FRgDNzc6AQoT3CAguYLWxoMR4W5TKCT1BCPpqjEN9mknmdMSKfYORs3djn/Yj/BhqtITTydDpBoREbzKY5+g==",
+      "version": "3.5.1",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.5.1.tgz",
+      "integrity": "sha512-JKPx+L1QNjtX1txpj+0+JJR3Q5D/IwKdocih8WTGXGYNYC8jdEDgaTkPb701gD/Jzu14foNn67W4CDDBvyPZeA==",
       "requires": {
         "adm-zip": "^0.5.9",
         "axios": "^1.2.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
-    "@octopusdeploy/api-client": "^3.4.1",
+    "@octopusdeploy/api-client": "^3.5.1",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "3.3.1",
     "azure-pipelines-tool-lib": "1.3.2",

--- a/source/tasks/RunRunbook/RunRunbookV6/inputCommandBuilder.test.ts
+++ b/source/tasks/RunRunbook/RunRunbookV6/inputCommandBuilder.test.ts
@@ -1,5 +1,5 @@
 import { Logger } from "@octopusdeploy/api-client";
-import { createCommandFromInputs } from "./inputCommandBuilder";
+import { createCommandFromInputs, CreateGitRunbookRunCommandV1, isCreateGitRunbookRunCommand } from "./inputCommandBuilder";
 import { MockTaskWrapper } from "../../Utils/MockTaskWrapper";
 
 describe("getInputCommand", () => {
@@ -20,6 +20,7 @@ describe("getInputCommand", () => {
         task.addVariableString("Variables", "var1: value1\nvar2: value2");
 
         const command = createCommandFromInputs(logger, task);
+        expect(isCreateGitRunbookRunCommand(command)).toBe(false);
         expect(command.spaceName).toBe("Default");
         expect(command.ProjectName).toBe("Awesome project");
         expect(command.RunbookName).toBe("A runbook");
@@ -27,6 +28,32 @@ describe("getInputCommand", () => {
         expect(command.Tenants).toStrictEqual(["Tenant 1", "Tenant 2"]);
         expect(command.TenantTags).toStrictEqual(["tag set 1/tag 1", "tag set 1/tag 2"]);
         expect(command.Variables).toStrictEqual({ var1: "value1", var2: "value2" });
+
+        expect(task.lastResult).toBeUndefined();
+        expect(task.lastResultMessage).toBeUndefined();
+        expect(task.lastResultDone).toBeUndefined();
+    });
+
+    test("when gitRef is supplied, the command contains the ref plus all regular fields supplied", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Project", "Awesome project");
+        task.addVariableString("Runbook", "A runbook");
+        task.addVariableString("Environments", "dev\nStaging");
+        task.addVariableString("Tenants", "Tenant 1\nTenant 2");
+        task.addVariableString("TenantTags", "tag set 1/tag 1\ntag set 1/tag 2");
+        task.addVariableString("Variables", "var1: value1\nvar2: value2");
+        task.addVariableString("GitRef", "some-ref");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(isCreateGitRunbookRunCommand(command)).toBe(true);
+        expect(command.spaceName).toBe("Default");
+        expect(command.ProjectName).toBe("Awesome project");
+        expect(command.RunbookName).toBe("A runbook");
+        expect(command.EnvironmentNames).toStrictEqual(["dev", "Staging"]);
+        expect(command.Tenants).toStrictEqual(["Tenant 1", "Tenant 2"]);
+        expect(command.TenantTags).toStrictEqual(["tag set 1/tag 1", "tag set 1/tag 2"]);
+        expect(command.Variables).toStrictEqual({ var1: "value1", var2: "value2" });
+        expect((command as CreateGitRunbookRunCommandV1).GitRef).toBe("some-ref");
 
         expect(task.lastResult).toBeUndefined();
         expect(task.lastResultMessage).toBeUndefined();

--- a/source/tasks/RunRunbook/RunRunbookV6/inputCommandBuilder.ts
+++ b/source/tasks/RunRunbook/RunRunbookV6/inputCommandBuilder.ts
@@ -1,8 +1,19 @@
 import { getLineSeparatedItems } from "../../Utils/inputs";
 import { CreateRunbookRunCommandV1, Logger, PromptedVariableValues } from "@octopusdeploy/api-client";
+import { RunGitRunbookCommand } from "@octopusdeploy/api-client/dist/features/projects/runbooks/runs/RunGitRunbookCommand";
 import { TaskWrapper } from "tasks/Utils/taskInput";
 
-export function createCommandFromInputs(logger: Logger, task: TaskWrapper): CreateRunbookRunCommandV1 {
+// The api-client doesn't have a type for this command that we can differentiate from CreateRunbookRunCommandV1
+// so we'll wrap it to make things easier.
+export type CreateGitRunbookRunCommandV1 = RunGitRunbookCommand & {
+    GitRef: string;
+};
+
+export function isCreateGitRunbookRunCommand(command: CreateRunbookRunCommandV1 | CreateGitRunbookRunCommandV1): command is CreateGitRunbookRunCommandV1 {
+    return (command as CreateGitRunbookRunCommandV1).GitRef !== undefined;
+}
+
+export function createCommandFromInputs(logger: Logger, task: TaskWrapper): CreateRunbookRunCommandV1 | CreateGitRunbookRunCommandV1 {
     const variablesMap: PromptedVariableValues | undefined = {};
 
     const variablesField = task.getInput("Variables");
@@ -24,6 +35,27 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     const tagsField = task.getInput("TenantTags");
     logger.debug?.("Tenant Tags: " + tagsField);
     const tags = getLineSeparatedItems(tagsField || "")?.map((t: string) => t.trim()) || [];
+
+    const gitRef = task.getInput("GitRef");
+    logger.debug?.("GitRef: " + gitRef);
+
+    if (gitRef) {
+        const command: CreateGitRunbookRunCommandV1 = {
+            spaceName: task.getInput("Space") || "",
+            ProjectName: task.getInput("Project", true) || "",
+            RunbookName: task.getInput("Runbook", true) || "",
+            EnvironmentNames: getLineSeparatedItems(environmentsField || "")?.map((t: string) => t.trim()) || [],
+            Tenants: getLineSeparatedItems(tenantsField || "")?.map((t: string) => t.trim()) || [],
+            TenantTags: tags,
+            UseGuidedFailure: task.getBoolean("UseGuidedFailure") || undefined,
+            Variables: variablesMap || undefined,
+            GitRef: gitRef,
+        };
+
+        logger.debug?.(JSON.stringify(command));
+
+        return command;
+    }
 
     const command: CreateRunbookRunCommandV1 = {
         spaceName: task.getInput("Space") || "",

--- a/source/tasks/RunRunbook/RunRunbookV6/task.json
+++ b/source/tasks/RunRunbook/RunRunbookV6/task.json
@@ -56,6 +56,14 @@
             "helpMarkDown": "The environment names to run the runbook for."
         },
         {
+            "name": "GitRef",
+            "type": "string",
+            "label": "Git Reference",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The Git reference to run the runbook for. Only applies when runbooks are stored in a Git repository for config-as-code enabled projects."
+        },        
+        {
             "name": "Tenants",
             "type": "multiLine",
             "label": "Tenant(s)",
@@ -86,14 +94,6 @@
             "defaultValue": "False",
             "required": false,
             "helpMarkDown": "Whether to use guided failure mode if errors occur during the run."
-        },
-        {
-            "name": "GitRef",
-            "type": "string",
-            "label": "Git Reference",
-            "defaultValue": "",
-            "required": false,
-            "helpMarkDown": "The Git reference to run the runbook for. Only applies when runbooks are stored in a Git repository for config-as-code enabled projects."
         }
     ],
     "OutputVariables": [

--- a/source/tasks/RunRunbook/RunRunbookV6/task.json
+++ b/source/tasks/RunRunbook/RunRunbookV6/task.json
@@ -86,6 +86,14 @@
             "defaultValue": "False",
             "required": false,
             "helpMarkDown": "Whether to use guided failure mode if errors occur during the run."
+        },
+        {
+            "name": "GitRef",
+            "type": "string",
+            "label": "Git Reference",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "The Git reference to run the runbook for. Only applies when runbooks are stored in a Git repository for config-as-code enabled projects."
         }
     ],
     "OutputVariables": [

--- a/source/vsts.md
+++ b/source/vsts.md
@@ -273,17 +273,18 @@ From version 6, the deploy release step is split into two seperate functions for
 
 #### 📥 Inputs
 
-| Name                       | Description                                                                                                                  |
-| :------------------------- | :--------------------------------------------------------------------------------------------------------------------------- |
-| `OctoConnectedServiceName` | **Required.** Name of the Octopus Server connection.                                                                         |
-| `Space`                    | **Required.** The Octopus space name the release is in.                                                                      |
-| `Project`                  | **Required.** The Octopus project name to deploy.                                                                            |
-| `Runbook`                  | **Required.** Runbook name to run.                                                                                           |
-| `Environments`             | **Required.** The environment names to run the runbook for. One tenant name per line.                                        |
-| `Tenants`                  | The tenant names to run the runbook for. One tenant name per line.                                                           |
-| `TenantTags`               | Run for all tenants with the given tag(s). One tenant tag per line in the format `tag set name/tag name`.                    |
-| `Variables`                | List of prompted variable values, one variable-value pair per line. Each variable should be in format `variable name: value` |
-| `UseGuidedFailure`         | Whether to use guided failure mode if errors occur during the run.                                                           |
+| Name                       | Description                                                                                                                                          |
+| :------------------------- | :--------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `OctoConnectedServiceName` | **Required.** Name of the Octopus Server connection.                                                                                                 |
+| `Space`                    | **Required.** The Octopus space name the release is in.                                                                                              |
+| `Project`                  | **Required.** The Octopus project name to deploy.                                                                                                    |
+| `Runbook`                  | **Required.** Runbook name to run.                                                                                                                   |
+| `Environments`             | **Required.** The environment names to run the runbook for. One environment name per line.                                                           |
+| `GitRef`                   | The Git reference to run the runbook for e.g. `main`. Only applies when runbooks are stored in a Git repository for config-as-code enabled projects. |
+| `Tenants`                  | The tenant names to run the runbook for. One tenant name per line.                                                                                   |
+| `TenantTags`               | Run for all tenants with the given tag(s). One tenant tag per line in the format `tag set name/tag name`.                                            |
+| `Variables`                | List of prompted variable values, one variable-value pair per line. Each variable should be in format `variable name: value`                         |
+| `UseGuidedFailure`         | Whether to use guided failure mode if errors occur during the run.                                                                                   |
 
 #### 📤 Outputs
 


### PR DESCRIPTION
Adds support for running runbooks that are stored in Git for config-as-code projects. It adds a new `GitRef` input (e.g. `main`) to the RunRunbookV6 task which if supplied will run the runbook for the given ref.

Fixes https://github.com/OctopusDeploy/Issues/issues/9249

## Examples

Pipeline with a step to a Git runbook and a Db runbook:
<img width="554" alt="image" src="https://github.com/user-attachments/assets/358620e1-8ce6-42c4-b65d-f14e39632e51" />

Logs of Git runbook being triggered and associated runbook run in Octopus:
<img width="497" alt="image" src="https://github.com/user-attachments/assets/1ed67a34-1680-4894-8b0a-c843fbfecbef" />
![image](https://github.com/user-attachments/assets/aa8af7c4-f98e-448d-a242-4265c9582bc9)

Logs of Db runbook being triggered and associated runbook run in Octopus:
<img width="494" alt="image" src="https://github.com/user-attachments/assets/18919eaa-c6a8-481b-8aab-592102aa5c0f" />
![image](https://github.com/user-attachments/assets/cb993de3-b053-44af-aa6c-6df0651dd6c0)
