### PR TITLE
Add progress logging to await task

### DIFF
--- a/source/tasks/AwaitTask/AwaitTaskV6/task.json
+++ b/source/tasks/AwaitTask/AwaitTaskV6/task.json
@@ -57,6 +57,14 @@
             "defaultValue": "600",
             "required": false,
             "helpMarkDown": "Duration, in seconds, to allow for completion before timing out. (Default: 600s)"
+        },
+        {
+            "name": "ShowProgress",
+            "type": "boolean",
+            "label": "Show Progress",
+            "defaultValue": "false",
+            "required": false,
+            "helpMarkDown": "Log Octopus task outputs to Azure DevOps output. (Default: false)"
         }
     ],
     "outputVariables": [

--- a/source/tasks/AwaitTask/AwaitTaskV6/waiter.ts
+++ b/source/tasks/AwaitTask/AwaitTaskV6/waiter.ts
@@ -1,7 +1,7 @@
-import { Client, Logger, ServerTaskWaiter, SpaceRepository, TaskState } from "@octopusdeploy/api-client";
+import { ActivityElement, ActivityLogEntryCategory, ActivityStatus, Client, Logger, ServerTask, ServerTaskWaiter, SpaceRepository, SpaceServerTaskRepository, TaskState } from "@octopusdeploy/api-client";
 import { OctoServerConnectionDetails } from "tasks/Utils/connection";
 import { TaskWrapper } from "tasks/Utils/taskInput";
-import { getInputParameters } from "./input-parameters";
+import { getInputParameters, InputParameters } from "./input-parameters";
 import { ExecutionResult } from "../../Utils/executionResult";
 import { getClient } from "../../Utils/client";
 
@@ -10,12 +10,12 @@ export interface WaitExecutionResult extends ExecutionResult {
 }
 
 export class Waiter {
-    constructor(readonly connection: OctoServerConnectionDetails, readonly task: TaskWrapper, readonly logger: Logger) {}
+    constructor(readonly connection: OctoServerConnectionDetails, readonly task: TaskWrapper, readonly logger: Logger) { }
 
     public async run() {
         const inputParameters = getInputParameters(this.logger, this.task);
 
-        const client = await getClient(this.connection, this.logger, "task", "wait", 6)
+        const client = await getClient(this.connection, this.logger, "task", "wait", 6);
 
         const waiter = new ServerTaskWaiter(client, inputParameters.space);
 
@@ -26,29 +26,78 @@ export class Waiter {
             lookup.set(t.serverTaskId, t);
             taskIds.push(t.serverTaskId);
         });
+        const taskRepository = new SpaceServerTaskRepository(client, inputParameters.space);
+        const loggedChildTaskIds: string[] = [];
+        const lastTaskUpdate: { [taskId: string]: string } = {};
 
         await waiter.waitForServerTasksToComplete(taskIds, inputParameters.pollingInterval * 1000, inputParameters.timeout * 1000, (t) => {
             let context = "";
             const taskResult = lookup.get(t.Id);
-            if (taskResult) {
-                if (taskResult?.environmentName) {
-                    context = ` to environment '${taskResult.environmentName}'`;
-                }
-                if (taskResult?.tenantName) {
-                    context += ` for tenant '${taskResult?.tenantName}'`;
-                }
+            if (!taskResult) return;
 
-                if (t.IsCompleted) {
-                    this.logger.info?.(`${taskResult.type}${context} ${t.State === TaskState.Success ? "completed successfully" : "did not complete successfully"}`);
-                } else {
-                    this.logger.info?.(`${taskResult.type}${context} is '${t.State}'`);
-                }
-
-                if (t.IsCompleted) {
-                    taskResult.successful = t.IsCompleted && t.State == TaskState.Success;
-                    waitExecutionResults.push(taskResult);
-                }
+            if (taskResult?.environmentName) {
+                context = ` to environment '${taskResult.environmentName}'`;
             }
+            if (taskResult?.tenantName) {
+                context += ` for tenant '${taskResult?.tenantName}'`;
+            }
+            if (t.IsCompleted) {
+                this.logger.info?.(`${taskResult.type}${context} ${t.State === TaskState.Success ? "completed successfully" : "did not complete successfully"}`);
+                taskResult.successful = t.IsCompleted && t.State == TaskState.Success;
+                waitExecutionResults.push(taskResult);
+                return;
+            }
+
+            const taskUpdate = `${taskResult.type}${context} is '${t.State}'`;
+            if (!inputParameters.showProgress) {
+                // Old task progress logger
+                this.logger.info?.(taskUpdate);
+                return;
+            }
+
+            // New task progress logger
+            if (loggedChildTaskIds.length == 0 && lastTaskUpdate[taskResult.serverTaskId] !== taskUpdate) {
+                // Log top level updates until we have details, don't log them again
+                this.logger.info?.(taskUpdate);
+                lastTaskUpdate[taskResult.serverTaskId] = taskUpdate;
+            }
+
+            // Log details of the task
+            this.logger.debug?.(`Fetching details on ${taskResult.serverTaskId}`);
+            taskRepository
+                .getDetails(t.Id)
+                .then((task) => {
+                    this.logger.debug?.(`Fetched details on ${taskResult.serverTaskId}: ${JSON.stringify(task)}`);
+
+                    task.ActivityLogs.flatMap((parentActivity) =>
+                        parentActivity.Children.filter(isComplete).map((activity) => {
+                            if (loggedChildTaskIds.includes(activity.Id)) return;
+
+                            this.logWithStatus(`\t${activity.Status}: ${activity.Name}`, activity.Status);
+
+                            if (activity.Started && activity.Ended) {
+                                const startTime = new Date(activity.Started);
+                                const endTime = new Date(activity.Ended);
+                                const duration = (endTime.getTime() - startTime.getTime()) / 1000;
+                                this.logger.info?.(`\t\t\t---------------------------------`);
+                                this.logger.info?.(`\t\t\tStarted: \t${activity.Started}\n\t\t\tEnded:   \t${activity.Ended}\n\t\t\tDuration:\t${duration.toFixed(1)}s`);
+                                this.logger.info?.(`\t\t\t---------------------------------`);
+                            }
+
+                            activity.Children.filter(isComplete)
+                                .flatMap((child) => child.LogElements)
+                                .forEach((log) => {
+                                    this.logWithCategory(`\t\t${log.OccurredAt}: ${log.MessageText}`, log.Category);
+                                    log.Detail && this.logger.debug?.(log.Detail);
+                                });
+
+                            loggedChildTaskIds.push(activity.Id);
+                        })
+                    );
+                })
+                .catch((e) => {
+                    this.logger.error?.(`Failed to fetch details on ${taskResult.serverTaskId}: ${e}`, e);
+                });
         });
 
         const spaceId = await this.getSpaceId(client, inputParameters.space);
@@ -86,4 +135,35 @@ export class Waiter {
     getContext(result: WaitExecutionResult): string {
         return result.tenantName ? result.tenantName.replace(" ", "_") : result.environmentName.replace(" ", "_");
     }
+
+    logWithCategory(message: string, category?: ActivityLogEntryCategory) {
+        switch (category) {
+            case "Error":
+            case "Fatal":
+                this.logger.error?.(message, undefined);
+                break;
+            case "Warning":
+                this.logger.warn?.(message);
+                break;
+            default:
+                this.logger.info?.(message);
+        }
+    }
+
+    logWithStatus(message: string, status?: ActivityStatus) {
+        switch (status) {
+            case "Failed":
+                this.logger.error?.(message, undefined);
+                break;
+            case "SuccessWithWarning":
+                this.logger.warn?.(message);
+                break;
+            default:
+                this.logger.info?.(message);
+        }
+    }
+}
+
+function isComplete(element: ActivityElement) {
+    return element.Status != "Pending" && element.Status != "Running";
 }

--- a/source/tasks/AwaitTask/AwaitTaskV6/waiter.ts
+++ b/source/tasks/AwaitTask/AwaitTaskV6/waiter.ts
@@ -1,4 +1,4 @@
-import { ActivityElement, ActivityLogEntryCategory, ActivityStatus, Client, Logger, ServerTask, ServerTaskWaiter, SpaceRepository, SpaceServerTaskRepository, TaskState } from "@octopusdeploy/api-client";
+import { ActivityElement, ActivityLogEntryCategory, ActivityStatus, Client, Logger, ServerTaskWaiter, SpaceRepository, SpaceServerTaskRepository, TaskState } from "@octopusdeploy/api-client";
 import { OctoServerConnectionDetails } from "tasks/Utils/connection";
 import { TaskWrapper } from "tasks/Utils/taskInput";
 import { getInputParameters, InputParameters } from "./input-parameters";
@@ -17,88 +17,7 @@ export class Waiter {
 
         const client = await getClient(this.connection, this.logger, "task", "wait", 6);
 
-        const waiter = new ServerTaskWaiter(client, inputParameters.space);
-
-        const taskIds: string[] = [];
-        const waitExecutionResults: WaitExecutionResult[] = [];
-        const lookup: Map<string, WaitExecutionResult> = new Map<string, WaitExecutionResult>();
-        inputParameters.tasks.map((t) => {
-            lookup.set(t.serverTaskId, t);
-            taskIds.push(t.serverTaskId);
-        });
-        const taskRepository = new SpaceServerTaskRepository(client, inputParameters.space);
-        const loggedChildTaskIds: string[] = [];
-        const lastTaskUpdate: { [taskId: string]: string } = {};
-
-        await waiter.waitForServerTasksToComplete(taskIds, inputParameters.pollingInterval * 1000, inputParameters.timeout * 1000, (t) => {
-            let context = "";
-            const taskResult = lookup.get(t.Id);
-            if (!taskResult) return;
-
-            if (taskResult?.environmentName) {
-                context = ` to environment '${taskResult.environmentName}'`;
-            }
-            if (taskResult?.tenantName) {
-                context += ` for tenant '${taskResult?.tenantName}'`;
-            }
-            if (t.IsCompleted) {
-                this.logger.info?.(`${taskResult.type}${context} ${t.State === TaskState.Success ? "completed successfully" : "did not complete successfully"}`);
-                taskResult.successful = t.IsCompleted && t.State == TaskState.Success;
-                waitExecutionResults.push(taskResult);
-                return;
-            }
-
-            const taskUpdate = `${taskResult.type}${context} is '${t.State}'`;
-            if (!inputParameters.showProgress) {
-                // Old task progress logger
-                this.logger.info?.(taskUpdate);
-                return;
-            }
-
-            // New task progress logger
-            if (loggedChildTaskIds.length == 0 && lastTaskUpdate[taskResult.serverTaskId] !== taskUpdate) {
-                // Log top level updates until we have details, don't log them again
-                this.logger.info?.(taskUpdate);
-                lastTaskUpdate[taskResult.serverTaskId] = taskUpdate;
-            }
-
-            // Log details of the task
-            this.logger.debug?.(`Fetching details on ${taskResult.serverTaskId}`);
-            taskRepository
-                .getDetails(t.Id)
-                .then((task) => {
-                    this.logger.debug?.(`Fetched details on ${taskResult.serverTaskId}: ${JSON.stringify(task)}`);
-
-                    task.ActivityLogs.flatMap((parentActivity) =>
-                        parentActivity.Children.filter(isComplete).map((activity) => {
-                            if (loggedChildTaskIds.includes(activity.Id)) return;
-
-                            this.logWithStatus(`\t${activity.Status}: ${activity.Name}`, activity.Status);
-
-                            if (activity.Started && activity.Ended) {
-                                const startTime = new Date(activity.Started);
-                                const endTime = new Date(activity.Ended);
-                                const duration = (endTime.getTime() - startTime.getTime()) / 1000;
-                                this.logger.info?.(`\t\t\t---------------------------------`);
-                                this.logger.info?.(`\t\t\tStarted: \t${activity.Started}\n\t\t\tEnded:   \t${activity.Ended}\n\t\t\tDuration:\t${duration.toFixed(1)}s`);
-                                this.logger.info?.(`\t\t\t---------------------------------`);
-                            }
-
-                            activity.Children.filter(isComplete)
-                                .flatMap((child) => child.LogElements)
-                                .forEach((log) => {
-                                    this.logWithCategory(`\t\t${log.OccurredAt}: ${log.MessageText}`, log.Category);
-                                    log.Detail && this.logger.debug?.(log.Detail);
-                                });
-
-                            loggedChildTaskIds.push(activity.Id);
-                        })
-                    );
-                })
-                .catch((e) => {
-                    this.logger.error?.(`Failed to fetch details on ${taskResult.serverTaskId}: ${e}`, e);
-                });
-        });
+        const waitExecutionResults = inputParameters.showProgress ? await this.waitWithProgress(client, inputParameters) : await this.waitWithoutProgress(client, inputParameters);
 
         const spaceId = await this.getSpaceId(client, inputParameters.space);
         let failedDeploymentsCount = 0;
@@ -134,6 +53,107 @@ export class Waiter {
 
     getContext(result: WaitExecutionResult): string {
         return result.tenantName ? result.tenantName.replace(" ", "_") : result.environmentName.replace(" ", "_");
+    }
+
+    async waitWithoutProgress(client: Client, inputParameters: InputParameters): Promise<WaitExecutionResult[]> {
+        const waiter = new ServerTaskWaiter(client, inputParameters.space);
+        const taskIds = inputParameters.tasks.map((t) => t.serverTaskId);
+        const lookup = new Map(inputParameters.tasks.map((t) => [t.serverTaskId, t]));
+
+        const results: WaitExecutionResult[] = [];
+
+        await waiter.waitForServerTasksToComplete(taskIds, inputParameters.pollingInterval * 1000, inputParameters.timeout * 1000, (t) => {
+            const taskResult = lookup.get(t.Id);
+            if (!taskResult) return;
+            const context = this.getProgressContext(taskResult);
+
+            if (!t.IsCompleted) {
+                this.logger.info?.(`${taskResult.type}${context} is '${t.State}'`);
+                return;
+            }
+
+            this.logger.info?.(`${taskResult.type}${context} ${t.State === TaskState.Success ? "completed successfully" : "did not complete successfully"}`);
+            taskResult.successful = t.State == TaskState.Success;
+            results.push(taskResult);
+        });
+        return results;
+    }
+
+    async waitWithProgress(client: Client, inputParameters: InputParameters): Promise<WaitExecutionResult[]> {
+        const waiter = new ServerTaskWaiter(client, inputParameters.space);
+        const taskIds = inputParameters.tasks.map((t) => t.serverTaskId);
+        const taskLookup = new Map(inputParameters.tasks.map((t) => [t.serverTaskId, t]));
+
+        const taskRepository = new SpaceServerTaskRepository(client, inputParameters.space);
+        const loggedChildTaskIds: string[] = [];
+        const lastTaskUpdate: { [taskId: string]: string } = {};
+
+        const results: WaitExecutionResult[] = [];
+
+        const promises: Promise<void>[] = [];
+        await waiter.waitForServerTasksToComplete(taskIds, inputParameters.pollingInterval * 1000, inputParameters.timeout * 1000, (t) => {
+            const taskResult = taskLookup.get(t.Id);
+            if (!taskResult) return;
+
+            const taskUpdate = `${taskResult.type}${this.getProgressContext(taskResult)} is '${t.State}'`;
+            if (loggedChildTaskIds.length == 0 && lastTaskUpdate[taskResult.serverTaskId] !== taskUpdate) {
+                // Log top level updates until we have details, don't log them again
+                this.logger.info?.(taskUpdate);
+                lastTaskUpdate[taskResult.serverTaskId] = taskUpdate;
+            }
+
+            // Log details of the task
+            const promise = this.printTaskDetails(taskRepository, taskResult, loggedChildTaskIds, results);
+            promises.push(promise);
+        });
+
+        await Promise.all(promises);
+        return results;
+    }
+
+    async printTaskDetails(repository: SpaceServerTaskRepository, task: WaitExecutionResult, loggedChildTaskIds: string[], results: WaitExecutionResult[]): Promise<void> {
+        try {
+            this.logger.debug?.(`Fetching details on ${task.serverTaskId}`);
+            const taskDetails = await repository.getDetails(task.serverTaskId);
+            this.logger.debug?.(`Fetched details on ${task.serverTaskId}: ${JSON.stringify(taskDetails)}`);
+
+            const activities = taskDetails.ActivityLogs.flatMap((parentActivity) => parentActivity.Children.filter(isComplete).filter((activity) => !loggedChildTaskIds.includes(activity.Id)));
+
+            for (const activity of activities) {
+                this.logWithStatus(`\t${activity.Status}: ${activity.Name}`, activity.Status);
+
+                if (activity.Started && activity.Ended) {
+                    const startTime = new Date(activity.Started);
+                    const endTime = new Date(activity.Ended);
+                    const duration = (endTime.getTime() - startTime.getTime()) / 1000;
+                    this.logger.info?.(`\t\t\t---------------------------------`);
+                    this.logger.info?.(`\t\t\tStarted: \t${activity.Started}\n\t\t\tEnded:   \t${activity.Ended}\n\t\t\tDuration:\t${duration.toFixed(1)}s`);
+                    this.logger.info?.(`\t\t\t---------------------------------`);
+                }
+
+                activity.Children.filter(isComplete)
+                    .flatMap((child) => child.LogElements)
+                    .forEach((log) => {
+                        this.logWithCategory(`\t\t${log.OccurredAt}: ${log.MessageText}`, log.Category);
+                        log.Detail && this.logger.debug?.(log.Detail);
+                    });
+
+                loggedChildTaskIds.push(activity.Id);
+            }
+            if (!taskDetails.Task.IsCompleted) return;
+
+            const message = taskDetails.Task.State === TaskState.Success ? "completed successfully" : "did not complete successfully";
+            this.logger.info?.(`${task.type}${this.getProgressContext(task)} ${message}`);
+            task.successful = taskDetails.Task.State === TaskState.Success;
+            results.push(task);
+        } catch (e) {
+            const error = e instanceof Error ? e : undefined;
+            this.logger.error?.(`Failed to fetch details on ${task}: ${e}`, error);
+        }
+    }
+
+    getProgressContext(task: WaitExecutionResult): string {
+        return `${task.environmentName ? ` to environment '${task.environmentName}'` : ""}${task.tenantName ? ` for tenant '${task.tenantName}'` : ""}`;
     }
 
     logWithCategory(message: string, category?: ActivityLogEntryCategory) {

--- a/source/vsts.md
+++ b/source/vsts.md
@@ -296,13 +296,14 @@ From version 6, the deploy release step is split into two seperate functions for
 
 #### 📥 Inputs
 
-| Name                       | Description                                                                      |
-| :------------------------- | :------------------------------------------------------------------------------- |
-| `OctoConnectedServiceName` | **Required.** Name of the Octopus Server connection.                             |
-| `Space`                    | **Required.** The Octopus space the release is in.                               |
-| `Step`                     | **Required** The name of the step that queued the deployment/runbook run.        |
-| `PollingInterval`          | How frequently, in seconds, to check the status. (Default: 10s)                  |
-| `TimeoutAfter`             | Duration, in seconds, to allow for completion before timing out. (Default: 600s) |
+| Name                          | Description                                                                       |
+| :---------------------------- | :-------------------------------------------------------------------------------- |
+| `OctoConnectedServiceName`    | **Required.** Name of the Octopus Server connection.                              |
+| `Space`                       | **Required.** The Octopus space the release is in.                                |
+| `Step`                        | **Required** The name of the step that queued the deployment/runbook run.         |
+| `PollingInterval`             | How frequently, in seconds, to check the status. (Default: 10s)                   |
+| `TimeoutAfter`                | Duration, in seconds, to allow for completion before timing out. (Default: 600s)  |
+| `ShowProgress`                | Log Octopus task outputs to Azure DevOps output. (Default: false)                 |
 
 The `Step` input parameter needs to be set to the `name` of the deployment step that generated the server tasks to be waited. In the classic-pipeline mode, you need to set the reference name on the `server_tasks` output variable and use that value for `Step`.
 


### PR DESCRIPTION
# Background
`OctopusDeployRelease` V5 allowed for the progress of the deployment to be shown. Since `OctopusDeployRelease` V6, the waiting for the deployment task to finish has been moved to the `OctopusAwaitTask`. However, this task is currently missing an option to show the progress of the deployment.

# Results
Adds a new optional `ShowProgress` flag to `OctopusAwaitTask` V6. 
Fixes #342
[sc-104339]
# Before
![image](https://github.com/user-attachments/assets/b5e1b69a-972a-47e0-9b11-619b0c54b3e7)
# After
![image](https://github.com/user-attachments/assets/0c5acf77-d12f-44ab-bfa6-280c1bc91244)

# Testing
This was tested on Azure DevOps Server 2022 and Azure DevOps Server 2019.

[Note that V6 Tasks are only supported on Azure DevOps Server 2019+](https://octopus.com/docs/packaging-applications/build-servers/tfs-azure-devops/using-octopus-extension/extension-compatibility#extension-compatibility-with-azure-devopsteam-foundation-server)

Functionality Tested:
 - Waiting on Deployments
 - Waiting on Runbooks

Scenarios Tested:
 - `ShowProgress` flag on/off
 - Failing tasks
 - Tasks with warnings
 - Successful tasks
 - Cancelling tasks