### PR TITLE
feat: Add retry parameters to OctopusAwaitTask

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,7 @@
   "packages": {
     "": {
       "dependencies": {
-        "@octopusdeploy/api-client": "^3.7.0",
+        "@octopusdeploy/api-client": "^3.11.0",
         "azure-devops-node-api": "11.2.0",
         "azure-pipelines-task-lib": "^4.13.0",
         "azure-pipelines-tool-lib": "^2.0.7",
@@ -1131,17 +1131,17 @@
       }
     },
     "node_modules/@octopusdeploy/api-client": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.7.0.tgz",
-      "integrity": "sha512-H3fPq+7qR+GO1QhBoLp9e40yyojB5T9hbdpcXqKl/7BEnBbDsj23eXjrua/w30Ajh5H6JI/yhsiH6bTqm5+IJw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.11.0.tgz",
+      "integrity": "sha512-wfy+JZmCIR7RX0eCjXb6M3cJW10jlIvT/rvr/Ts7yyeEJwiG0QLCBEywr1kvhe85x1wwBGBKnlJGk/IzZbiJwQ==",
       "license": "Apache-2.0",
       "dependencies": {
         "adm-zip": "^0.5.9",
-        "axios": "^1.8.2",
-        "form-data": "^4.0.0",
+        "axios": "^1.12.2",
+        "form-data": "^4.0.4",
         "glob": "^8.0.3",
         "lodash": "^4.17.21",
-        "semver": "^7.3.8",
+        "semver": "^7.7.2",
         "urijs": "^1.19.11"
       }
     },
@@ -1979,16 +1979,17 @@
     "node_modules/asynckit": {
       "version": "0.4.0",
       "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
-      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "license": "MIT"
     },
     "node_modules/axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "license": "MIT",
       "dependencies": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -2508,6 +2509,7 @@
       "version": "1.0.8",
       "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
       "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "license": "MIT",
       "dependencies": {
         "delayed-stream": "~1.0.0"
       },
@@ -2692,6 +2694,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
       "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "license": "MIT",
       "engines": {
         "node": ">=0.4.0"
       }
@@ -3818,9 +3821,9 @@
       }
     },
     "node_modules/form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "license": "MIT",
       "dependencies": {
         "asynckit": "^0.4.0",
@@ -5251,17 +5254,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "node_modules/lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "dependencies": {
-        "yallist": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=10"
-      }
-    },
     "node_modules/make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -6150,12 +6142,10 @@
       }
     },
     "node_modules/semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "dependencies": {
-        "lru-cache": "^6.0.0"
-      },
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q==",
+      "license": "ISC",
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -7042,11 +7032,6 @@
       "engines": {
         "node": ">=10"
       }
-    },
-    "node_modules/yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "node_modules/yargs": {
       "version": "17.5.1",
@@ -7957,16 +7942,16 @@
       }
     },
     "@octopusdeploy/api-client": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.7.0.tgz",
-      "integrity": "sha512-H3fPq+7qR+GO1QhBoLp9e40yyojB5T9hbdpcXqKl/7BEnBbDsj23eXjrua/w30Ajh5H6JI/yhsiH6bTqm5+IJw==",
+      "version": "3.11.0",
+      "resolved": "https://registry.npmjs.org/@octopusdeploy/api-client/-/api-client-3.11.0.tgz",
+      "integrity": "sha512-wfy+JZmCIR7RX0eCjXb6M3cJW10jlIvT/rvr/Ts7yyeEJwiG0QLCBEywr1kvhe85x1wwBGBKnlJGk/IzZbiJwQ==",
       "requires": {
         "adm-zip": "^0.5.9",
-        "axios": "^1.8.2",
-        "form-data": "^4.0.0",
+        "axios": "^1.12.2",
+        "form-data": "^4.0.4",
         "glob": "^8.0.3",
         "lodash": "^4.17.21",
-        "semver": "^7.3.8",
+        "semver": "^7.7.2",
         "urijs": "^1.19.11"
       },
       "dependencies": {
@@ -8652,12 +8637,12 @@
       "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q=="
     },
     "axios": {
-      "version": "1.10.0",
-      "resolved": "https://registry.npmjs.org/axios/-/axios-1.10.0.tgz",
-      "integrity": "sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-1.13.2.tgz",
+      "integrity": "sha512-VPk9ebNqPcy5lRGuSlKx752IlDatOjT9paPlm8A7yOuW2Fbvp4X3JznJtT4f0GzGLLiWE9W8onz51SqLYwzGaA==",
       "requires": {
         "follow-redirects": "^1.15.6",
-        "form-data": "^4.0.0",
+        "form-data": "^4.0.4",
         "proxy-from-env": "^1.1.0"
       }
     },
@@ -9946,9 +9931,9 @@
       "integrity": "sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ=="
     },
     "form-data": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.3.tgz",
-      "integrity": "sha512-qsITQPfmvMOSAdeyZ+12I1c+CKSstAFAwu+97zrnWAbIr5u8wfsExUzCesVLC8NgHuRUqNN4Zy6UPWUTRGslcA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
       "requires": {
         "asynckit": "^0.4.0",
         "combined-stream": "^1.0.8",
@@ -11019,14 +11004,6 @@
       "integrity": "sha512-c4pB2CdGrGdjMKYLA+XiRDO7Y0PRQbm/Gzg8qMj+QH+pFVAoTp5sBpO0odL3FjoPCGjK96p6qsP+yQoiLoOBcw==",
       "dev": true
     },
-    "lru-cache": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-6.0.0.tgz",
-      "integrity": "sha512-Jo6dJ04CmSjuznwJSS3pUeWmd/H0ffTlkXXgwZi+eq1UCmqQwCh+eLsYOYCwY991i2Fah4h1BEMCx4qThGbsiA==",
-      "requires": {
-        "yallist": "^4.0.0"
-      }
-    },
     "make-dir": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-3.1.0.tgz",
@@ -11652,12 +11629,9 @@
       }
     },
     "semver": {
-      "version": "7.3.8",
-      "resolved": "https://registry.npmjs.org/semver/-/semver-7.3.8.tgz",
-      "integrity": "sha512-NB1ctGL5rlHrPJtFDVIVzTyQylMLu9N9VICA6HSFJo8MCGVTMW6gfpicwKmmK/dAjTOrqu5l63JJOpDSrAis3A==",
-      "requires": {
-        "lru-cache": "^6.0.0"
-      }
+      "version": "7.7.3",
+      "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.3.tgz",
+      "integrity": "sha512-SdsKMrI9TdgjdweUSR9MweHA4EJ8YxHn8DFaDisvhVlUOe4BF1tLD7GAj0lIqWVl+dPb/rExr0Btby5loQm20Q=="
     },
     "semver-compare": {
       "version": "1.0.0",
@@ -12314,11 +12288,6 @@
       "resolved": "https://registry.npmjs.org/y18n/-/y18n-5.0.8.tgz",
       "integrity": "sha512-0pfFzegeDWJHJIAmTLRP2DwHjdF5s7jo9tuztdQxAhINCdvS+3nGINqPd00AphqJR/0LhANUS6/+7SCb98YOfA==",
       "dev": true
-    },
-    "yallist": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/yallist/-/yallist-4.0.0.tgz",
-      "integrity": "sha512-3wdGidZyq5PB084XLES5TpOSRA3wjXAlIWMhum2kRcv/41Sn2emQ0dycQW4uZXLejwKvg6EsvbdlVL+FYEct7A=="
     },
     "yargs": {
       "version": "17.5.1",

--- a/package.json
+++ b/package.json
@@ -38,7 +38,7 @@
     "yargs": "^17.5.1"
   },
   "dependencies": {
-    "@octopusdeploy/api-client": "^3.7.0",
+    "@octopusdeploy/api-client": "^3.11.0",
     "azure-devops-node-api": "11.2.0",
     "azure-pipelines-task-lib": "^4.13.0",
     "azure-pipelines-tool-lib": "^2.0.7",

--- a/source/tasks/AwaitTask/AwaitTaskV6/input-parameters.ts
+++ b/source/tasks/AwaitTask/AwaitTaskV6/input-parameters.ts
@@ -10,6 +10,8 @@ export interface InputParameters {
     timeout: number;
     showProgress: boolean;
     cancelOnTimeout: boolean;
+    maxRetries: number;
+    retryBackoffSeconds: number;
 }
 
 export function getInputParameters(logger: Logger, task: TaskWrapper): InputParameters {
@@ -51,6 +53,28 @@ export function getInputParameters(logger: Logger, task: TaskWrapper): InputPara
 
     const cancelOnTimeout = task.getBoolean("CancelOnTimeout") ?? false;
 
+    let maxRetries = 3;
+    const maxRetriesField = task.getInput("MaxRetries");
+    if (maxRetriesField) {
+        const parsed = parseInt(maxRetriesField, 10);
+        if (!isNaN(parsed)) {
+            maxRetries = parsed;
+        } else {
+            logger.warn?.(`Invalid MaxRetries value '${maxRetriesField}', using default: 3`);
+        }
+    }
+
+    let retryBackoffSeconds = 5;
+    const retryBackoffField = task.getInput("RetryBackoffSeconds");
+    if (retryBackoffField) {
+        const parsed = parseInt(retryBackoffField, 10);
+        if (!isNaN(parsed)) {
+            retryBackoffSeconds = parsed;
+        } else {
+            logger.warn?.(`Invalid RetryBackoffSeconds value '${retryBackoffField}', using default: 5`);
+        }
+    }
+
     const parameters: InputParameters = {
         space: task.getInput("Space") || "",
         step: step,
@@ -58,7 +82,9 @@ export function getInputParameters(logger: Logger, task: TaskWrapper): InputPara
         showProgress: showProgress,
         pollingInterval: pollingInterval,
         timeout: timeoutSeconds,
-        cancelOnTimeout: cancelOnTimeout
+        cancelOnTimeout: cancelOnTimeout,
+        maxRetries: maxRetries,
+        retryBackoffSeconds: retryBackoffSeconds
     };
 
     const errors: string[] = [];

--- a/source/tasks/AwaitTask/AwaitTaskV6/task.json
+++ b/source/tasks/AwaitTask/AwaitTaskV6/task.json
@@ -73,6 +73,22 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Cancel the Octopus task and mark this task as failed if the timeout is reached. (Default: false)"
+        },
+        {
+            "name": "MaxRetries",
+            "type": "int",
+            "label": "Max Retries",
+            "defaultValue": "3",
+            "required": false,
+            "helpMarkDown": "Number of times to retry failed HTTP requests due to network issues before failing. (Default: 3)"
+        },
+        {
+            "name": "RetryBackoffSeconds",
+            "type": "int",
+            "label": "Retry Backoff (seconds)",
+            "defaultValue": "5",
+            "required": false,
+            "helpMarkDown": "Initial delay between retries. Delay doubles with each retry (exponential backoff). (Default: 5s, then 10s, 20s, etc.)"
         }
     ],
     "outputVariables": [

--- a/source/tasks/AwaitTask/AwaitTaskV7/input-parameters.ts
+++ b/source/tasks/AwaitTask/AwaitTaskV7/input-parameters.ts
@@ -10,6 +10,8 @@ export interface InputParameters {
     timeout: number;
     showProgress: boolean;
     cancelOnTimeout: boolean;
+    maxRetries: number;
+    retryBackoffSeconds: number;
 }
 
 export function getInputParameters(logger: Logger, task: TaskWrapper): InputParameters {
@@ -51,6 +53,28 @@ export function getInputParameters(logger: Logger, task: TaskWrapper): InputPara
 
     const cancelOnTimeout = task.getBoolean("CancelOnTimeout") ?? false;
 
+    let maxRetries = 3;
+    const maxRetriesField = task.getInput("MaxRetries");
+    if (maxRetriesField) {
+        const parsed = parseInt(maxRetriesField, 10);
+        if (!isNaN(parsed)) {
+            maxRetries = parsed;
+        } else {
+            logger.warn?.(`Invalid MaxRetries value '${maxRetriesField}', using default: 3`);
+        }
+    }
+
+    let retryBackoffSeconds = 5;
+    const retryBackoffField = task.getInput("RetryBackoffSeconds");
+    if (retryBackoffField) {
+        const parsed = parseInt(retryBackoffField, 10);
+        if (!isNaN(parsed)) {
+            retryBackoffSeconds = parsed;
+        } else {
+            logger.warn?.(`Invalid RetryBackoffSeconds value '${retryBackoffField}', using default: 5`);
+        }
+    }
+
     const parameters: InputParameters = {
         space: task.getInput("Space") || "",
         step: step,
@@ -58,7 +82,9 @@ export function getInputParameters(logger: Logger, task: TaskWrapper): InputPara
         showProgress: showProgress,
         pollingInterval: pollingInterval,
         timeout: timeoutSeconds,
-        cancelOnTimeout: cancelOnTimeout
+        cancelOnTimeout: cancelOnTimeout,
+        maxRetries: maxRetries,
+        retryBackoffSeconds: retryBackoffSeconds
     };
 
     const errors: string[] = [];

--- a/source/tasks/AwaitTask/AwaitTaskV7/task.json
+++ b/source/tasks/AwaitTask/AwaitTaskV7/task.json
@@ -73,6 +73,22 @@
             "defaultValue": "false",
             "required": false,
             "helpMarkDown": "Cancel the Octopus task and mark this task as failed if the timeout is reached. (Default: false)"
+        },
+        {
+            "name": "MaxRetries",
+            "type": "int",
+            "label": "Max Retries",
+            "defaultValue": "3",
+            "required": false,
+            "helpMarkDown": "Number of times to retry failed HTTP requests due to network issues before failing. (Default: 3)"
+        },
+        {
+            "name": "RetryBackoffSeconds",
+            "type": "int",
+            "label": "Retry Backoff (seconds)",
+            "defaultValue": "5",
+            "required": false,
+            "helpMarkDown": "Initial delay between retries. Delay doubles with each retry (exponential backoff). (Default: 5s, then 10s, 20s, etc.)"
         }
     ],
     "outputVariables": [


### PR DESCRIPTION
### Background
Adds `MaxRetries` and `RetryBackoffSeconds` parameters to configure retry behavior for transient network failures.
#### Changes
- New parameters (V6 and V7):
  - **MaxRetries** (default: 3) - Maximum retry attempts
  - **RetryBackoffSeconds** (default: 5) - Initial backoff delay with exponential increase
- Enhanced error messages with troubleshooting guidance for network failures
- Passes configuration to `@octopusdeploy/api-client` retry logic

#### Example
```yaml
- task: OctopusAwaitTask@7
  inputs:
    MaxRetries: 5
    RetryBackoffSeconds: 10
```

### Result
[sc-124345]
- Pipelines automatically recover from transient network issues
- Configurable retry behavior
- Clear error messages with resolution guidance
- No breaking changes (existing pipelines work with defaults)
<img width="1370" height="685" alt="image" src="https://github.com/user-attachments/assets/bfda9b05-0d22-44e6-93aa-9683b34bea9e" />
