### PR TITLE
Add deploy task support for DeployAt and DeployAtExpiry

### DIFF
--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
@@ -131,4 +131,24 @@ describe("getInputCommand", () => {
         expect(command.RunAt).toBeUndefined();
         expect(command.NoRunAfter).toBeUndefined();
     });
+
+    test("invalid DeployAt throws error", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "notadate");
+
+        expect(() => createCommandFromInputs(logger, task)).toThrowError("DeployAt 'notadate' is not a valid ISO 8601 date-time string.");
+    });
+
+    test("invalid DeployAtExpiry throws error", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAtExpiry", "notadate");
+
+        expect(() => createCommandFromInputs(logger, task)).toThrowError("DeployAtExpiry 'notadate' is not a valid ISO 8601 date-time string.");
+    });
 });

--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.test.ts
@@ -95,4 +95,40 @@ describe("getInputCommand", () => {
         const command = createCommandFromInputs(logger, task);
         expect(command.EnvironmentNames).toStrictEqual(["dev", "test", "prod"]);
     });
+
+    test("DeployAt populates RunAt", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "2026-04-02T09:00:00+10:00");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toStrictEqual(new Date("2026-04-02T09:00:00+10:00"));
+        expect(command.NoRunAfter).toBeUndefined();
+    });
+
+    test("DeployAtExpiry populates NoRunAfter", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "2026-04-02T09:00:00+10:00");
+        task.addVariableString("DeployAtExpiry", "2026-04-02T17:00:00+10:00");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toStrictEqual(new Date("2026-04-02T09:00:00+10:00"));
+        expect(command.NoRunAfter).toStrictEqual(new Date("2026-04-02T17:00:00+10:00"));
+    });
+
+    test("DeployAt and DeployAtExpiry absent when inputs not provided", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toBeUndefined();
+        expect(command.NoRunAfter).toBeUndefined();
+    });
 });

--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
@@ -44,6 +44,9 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     }
     logger.debug?.("Environments:" + environmentsField);
 
+    const deployAt = task.getInput("DeployAt");
+    const deployAtExpiry = task.getInput("DeployAtExpiry");
+
     const command: CreateDeploymentUntenantedCommandV1 = {
         spaceName: task.getInput("Space", true) || "",
         ProjectName: task.getInput("Project", true) || "",
@@ -51,6 +54,8 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         EnvironmentNames: environments,
         UseGuidedFailure: task.getBoolean("UseGuidedFailure") || undefined,
         Variables: variablesMap || undefined,
+        RunAt: deployAt ? new Date(deployAt) : undefined,
+        NoRunAfter: deployAtExpiry ? new Date(deployAtExpiry) : undefined,
     };
 
     const errors: string[] = [];

--- a/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
+++ b/source/tasks/Deploy/DeployV6/inputCommandBuilder.ts
@@ -62,6 +62,12 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     if (command.spaceName === "") {
         errors.push("The Octopus space name is required.");
     }
+    if (deployAt && isNaN(new Date(deployAt).getTime())) {
+        errors.push(`DeployAt '${deployAt}' is not a valid ISO 8601 date-time string.`);
+    }
+    if (deployAtExpiry && isNaN(new Date(deployAtExpiry).getTime())) {
+        errors.push(`DeployAtExpiry '${deployAtExpiry}' is not a valid ISO 8601 date-time string.`);
+    }
 
     if (errors.length > 0) {
         throw new Error("Failed to successfully build parameters.\n" + errors.join("\n"));

--- a/source/tasks/Deploy/DeployV6/task.json
+++ b/source/tasks/Deploy/DeployV6/task.json
@@ -82,6 +82,24 @@
             "helpMarkDown": "Whether to use guided failure mode if errors occur during the deployment."
         },
         {
+            "name": "DeployAt",
+            "type": "string",
+            "label": "Scheduled deployment time",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Schedule the deployment to run at a specific time. Accepts an ISO 8601 date-time string.",
+            "groupName": "advanced"
+        },
+        {
+            "name": "DeployAtExpiry",
+            "type": "string",
+            "label": "Deployment expiry time",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Cancel the deployment if it has not started by this time. Accepts an ISO 8601 date-time string.",
+            "groupName": "advanced"
+        },
+        {
             "name": "AdditionalArguments",
             "type": "string",
             "label": "Additional Arguments (deprecated)",

--- a/source/tasks/Deploy/DeployV7/inputCommandBuilder.test.ts
+++ b/source/tasks/Deploy/DeployV7/inputCommandBuilder.test.ts
@@ -131,4 +131,24 @@ describe("getInputCommand", () => {
         expect(command.RunAt).toBeUndefined();
         expect(command.NoRunAfter).toBeUndefined();
     });
+
+    test("invalid DeployAt throws error", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "notadate");
+
+        expect(() => createCommandFromInputs(logger, task)).toThrowError("DeployAt 'notadate' is not a valid ISO 8601 date-time string.");
+    });
+
+    test("invalid DeployAtExpiry throws error", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAtExpiry", "notadate");
+
+        expect(() => createCommandFromInputs(logger, task)).toThrowError("DeployAtExpiry 'notadate' is not a valid ISO 8601 date-time string.");
+    });
 });

--- a/source/tasks/Deploy/DeployV7/inputCommandBuilder.test.ts
+++ b/source/tasks/Deploy/DeployV7/inputCommandBuilder.test.ts
@@ -95,4 +95,40 @@ describe("getInputCommand", () => {
         const command = createCommandFromInputs(logger, task);
         expect(command.EnvironmentNames).toStrictEqual(["dev", "test", "prod"]);
     });
+
+    test("DeployAt populates RunAt", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "2026-04-02T09:00:00+10:00");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toStrictEqual(new Date("2026-04-02T09:00:00+10:00"));
+        expect(command.NoRunAfter).toBeUndefined();
+    });
+
+    test("DeployAtExpiry populates NoRunAfter", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+        task.addVariableString("DeployAt", "2026-04-02T09:00:00+10:00");
+        task.addVariableString("DeployAtExpiry", "2026-04-02T17:00:00+10:00");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toStrictEqual(new Date("2026-04-02T09:00:00+10:00"));
+        expect(command.NoRunAfter).toStrictEqual(new Date("2026-04-02T17:00:00+10:00"));
+    });
+
+    test("DeployAt and DeployAtExpiry absent when inputs not provided", () => {
+        task.addVariableString("Space", "Default");
+        task.addVariableString("Environments", "test");
+        task.addVariableString("Project", "project 1");
+        task.addVariableString("ReleaseNumber", "1.2.3");
+
+        const command = createCommandFromInputs(logger, task);
+        expect(command.RunAt).toBeUndefined();
+        expect(command.NoRunAfter).toBeUndefined();
+    });
 });

--- a/source/tasks/Deploy/DeployV7/inputCommandBuilder.ts
+++ b/source/tasks/Deploy/DeployV7/inputCommandBuilder.ts
@@ -44,6 +44,9 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     }
     logger.debug?.("Environments:" + environmentsField);
 
+    const deployAt = task.getInput("DeployAt");
+    const deployAtExpiry = task.getInput("DeployAtExpiry");
+
     const command: CreateDeploymentUntenantedCommandV1 = {
         spaceName: task.getInput("Space", true) || "",
         ProjectName: task.getInput("Project", true) || "",
@@ -51,6 +54,8 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
         EnvironmentNames: environments,
         UseGuidedFailure: task.getBoolean("UseGuidedFailure") || undefined,
         Variables: variablesMap || undefined,
+        RunAt: deployAt ? new Date(deployAt) : undefined,
+        NoRunAfter: deployAtExpiry ? new Date(deployAtExpiry) : undefined,
     };
 
     const errors: string[] = [];

--- a/source/tasks/Deploy/DeployV7/inputCommandBuilder.ts
+++ b/source/tasks/Deploy/DeployV7/inputCommandBuilder.ts
@@ -62,6 +62,12 @@ export function createCommandFromInputs(logger: Logger, task: TaskWrapper): Crea
     if (command.spaceName === "") {
         errors.push("The Octopus space name is required.");
     }
+    if (deployAt && isNaN(new Date(deployAt).getTime())) {
+        errors.push(`DeployAt '${deployAt}' is not a valid ISO 8601 date-time string.`);
+    }
+    if (deployAtExpiry && isNaN(new Date(deployAtExpiry).getTime())) {
+        errors.push(`DeployAtExpiry '${deployAtExpiry}' is not a valid ISO 8601 date-time string.`);
+    }
 
     if (errors.length > 0) {
         throw new Error("Failed to successfully build parameters.\n" + errors.join("\n"));

--- a/source/tasks/Deploy/DeployV7/task.json
+++ b/source/tasks/Deploy/DeployV7/task.json
@@ -82,6 +82,24 @@
             "helpMarkDown": "Whether to use guided failure mode if errors occur during the deployment."
         },
         {
+            "name": "DeployAt",
+            "type": "string",
+            "label": "Scheduled deployment time",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Schedule the deployment to run at a specific time. Accepts an ISO 8601 date-time string.",
+            "groupName": "advanced"
+        },
+        {
+            "name": "DeployAtExpiry",
+            "type": "string",
+            "label": "Deployment expiry time",
+            "defaultValue": "",
+            "required": false,
+            "helpMarkDown": "Cancel the deployment if it has not started by this time. Accepts an ISO 8601 date-time string.",
+            "groupName": "advanced"
+        },
+        {
             "name": "AdditionalArguments",
             "type": "string",
             "label": "Additional Arguments (deprecated)",


### PR DESCRIPTION
Adds `DeployAt` and `DeployAtExpiry` inputs to the Deploy Release task (Deploy V6 and V7).

Prior to the replacement of the .NET CLI with the Executions API deprecation in V6, users could pass `--deployAt` and `--deployAtExpiry` as raw command line parameters via the now deprecated `AdditionalArguments` input. When the CLI was swapped out for the TypeScript client, these were not ported to first-class inputs. 

Both inputs are optional (surfaced under "Additional Options") and accept ISO 8601 date-time strings.

<img width="433" height="884" alt="ado-scheduled-start-time-ado-task" src="https://github.com/user-attachments/assets/dfd72a23-8003-48ff-a600-369af8d1ca22" />